### PR TITLE
chore: Example callables for operations mixin

### DIFF
--- a/java-speech/google-cloud-speech/pom.xml
+++ b/java-speech/google-cloud-speech/pom.xml
@@ -73,6 +73,7 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-httpjson</artifactId>
+      <version>0.110.110-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.threeten</groupId>

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/Main.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/Main.java
@@ -1,0 +1,50 @@
+package com.google.cloud.speech.v1;
+
+import com.google.api.gax.longrunning.OperationFuture;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+public class Main {
+    public static void main(String[] args)
+            throws IOException, ExecutionException, InterruptedException {
+        String gcsUri = "gs://cloud-samples-data/speech/brooklyn_bridge.raw";
+        RecognitionConfig recognitionConfig =
+                RecognitionConfig.newBuilder()
+                        .setEncoding(RecognitionConfig.AudioEncoding.LINEAR16)
+                        .setSampleRateHertz(16000)
+                        .setLanguageCode("en-US")
+                        .build();
+        RecognitionAudio recognitionAudio = RecognitionAudio.newBuilder().setUri(gcsUri).build();
+
+//    System.out.println("Running with gRPC...");
+//    try (SpeechClient speechClient = SpeechClient.create()) {
+//      testSpeechRecognize(speechClient, recognitionConfig, recognitionAudio);
+//    }
+
+        System.out.println("Running with REST...");
+        SpeechSettings speechSettings = SpeechSettings.newHttpJsonBuilder().build();
+        try (SpeechClient speechClient = SpeechClient.create(speechSettings)) {
+            testSpeechRecognize(speechClient, recognitionConfig, recognitionAudio);
+        }
+    }
+
+    public static void testSpeechRecognize(
+            SpeechClient speechClient,
+            RecognitionConfig recognitionConfig,
+            RecognitionAudio recognitionAudio)
+            throws ExecutionException, InterruptedException {
+        OperationFuture<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> operationFuture = speechClient.longRunningRecognizeAsync(
+                LongRunningRecognizeRequest.newBuilder()
+                        .setConfig(recognitionConfig)
+                        .setAudio(recognitionAudio)
+                        .build());
+        LongRunningRecognizeResponse longRunningRecognizeResponse = operationFuture.get();
+        List<SpeechRecognitionResult> speechRecognitionResultOperationList = longRunningRecognizeResponse.getResultsList();
+        for (SpeechRecognitionResult speechRecognitionResult : speechRecognitionResultOperationList) {
+            System.out.println(
+                    "Transcript: " + speechRecognitionResult.getAlternatives(0).getTranscript());
+        }
+    }
+}

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/Main.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/Main.java
@@ -1,50 +1,51 @@
 package com.google.cloud.speech.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 public class Main {
-    public static void main(String[] args)
-            throws IOException, ExecutionException, InterruptedException {
-        String gcsUri = "gs://cloud-samples-data/speech/brooklyn_bridge.raw";
-        RecognitionConfig recognitionConfig =
-                RecognitionConfig.newBuilder()
-                        .setEncoding(RecognitionConfig.AudioEncoding.LINEAR16)
-                        .setSampleRateHertz(16000)
-                        .setLanguageCode("en-US")
-                        .build();
-        RecognitionAudio recognitionAudio = RecognitionAudio.newBuilder().setUri(gcsUri).build();
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+    String gcsUri = "gs://cloud-samples-data/speech/brooklyn_bridge.raw";
+    RecognitionConfig recognitionConfig =
+        RecognitionConfig.newBuilder()
+            .setEncoding(RecognitionConfig.AudioEncoding.LINEAR16)
+            .setSampleRateHertz(16000)
+            .setLanguageCode("en-US")
+            .build();
+    RecognitionAudio recognitionAudio = RecognitionAudio.newBuilder().setUri(gcsUri).build();
 
-//    System.out.println("Running with gRPC...");
-//    try (SpeechClient speechClient = SpeechClient.create()) {
-//      testSpeechRecognize(speechClient, recognitionConfig, recognitionAudio);
-//    }
+    //    System.out.println("Running with gRPC...");
+    //    try (SpeechClient speechClient = SpeechClient.create()) {
+    //      testSpeechRecognize(speechClient, recognitionConfig, recognitionAudio);
+    //    }
 
-        System.out.println("Running with REST...");
-        SpeechSettings speechSettings = SpeechSettings.newHttpJsonBuilder().build();
-        try (SpeechClient speechClient = SpeechClient.create(speechSettings)) {
-            testSpeechRecognize(speechClient, recognitionConfig, recognitionAudio);
-        }
+    System.out.println("Running with REST...");
+    SpeechSettings speechSettings = SpeechSettings.newHttpJsonBuilder().build();
+    try (SpeechClient speechClient = SpeechClient.create(speechSettings)) {
+      testSpeechRecognize(speechClient, recognitionConfig, recognitionAudio);
     }
+  }
 
-    public static void testSpeechRecognize(
-            SpeechClient speechClient,
-            RecognitionConfig recognitionConfig,
-            RecognitionAudio recognitionAudio)
-            throws ExecutionException, InterruptedException {
-        OperationFuture<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> operationFuture = speechClient.longRunningRecognizeAsync(
-                LongRunningRecognizeRequest.newBuilder()
-                        .setConfig(recognitionConfig)
-                        .setAudio(recognitionAudio)
-                        .build());
-        LongRunningRecognizeResponse longRunningRecognizeResponse = operationFuture.get();
-        List<SpeechRecognitionResult> speechRecognitionResultOperationList = longRunningRecognizeResponse.getResultsList();
-        for (SpeechRecognitionResult speechRecognitionResult : speechRecognitionResultOperationList) {
-            System.out.println(
-                    "Transcript: " + speechRecognitionResult.getAlternatives(0).getTranscript());
-        }
+  public static void testSpeechRecognize(
+      SpeechClient speechClient,
+      RecognitionConfig recognitionConfig,
+      RecognitionAudio recognitionAudio)
+      throws ExecutionException, InterruptedException {
+    OperationFuture<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> operationFuture =
+        speechClient.longRunningRecognizeAsync(
+            LongRunningRecognizeRequest.newBuilder()
+                .setConfig(recognitionConfig)
+                .setAudio(recognitionAudio)
+                .build());
+    LongRunningRecognizeResponse longRunningRecognizeResponse = operationFuture.get();
+    List<SpeechRecognitionResult> speechRecognitionResultOperationList =
+        longRunningRecognizeResponse.getResultsList();
+    for (SpeechRecognitionResult speechRecognitionResult : speechRecognitionResultOperationList) {
+      System.out.println(
+          "Transcript: " + speechRecognitionResult.getAlternatives(0).getTranscript());
     }
+  }
 }

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/SpeechClient.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/SpeechClient.java
@@ -16,17 +16,32 @@
 
 package com.google.cloud.speech.v1;
 
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.httpjson.longrunning.OperationsClient;
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.paging.AbstractFixedSizeCollection;
+import com.google.api.gax.paging.AbstractPage;
+import com.google.api.gax.paging.AbstractPagedListResponse;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.PageContext;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.speech.v1.stub.SpeechStub;
 import com.google.cloud.speech.v1.stub.SpeechStubSettings;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.longrunning.CancelOperationRequest;
+import com.google.longrunning.DeleteOperationRequest;
+import com.google.longrunning.GetOperationRequest;
+import com.google.longrunning.ListOperationsRequest;
+import com.google.longrunning.ListOperationsResponse;
 import com.google.longrunning.Operation;
+import com.google.longrunning.WaitOperationRequest;
+import com.google.protobuf.Empty;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
 
@@ -154,7 +169,7 @@ public class SpeechClient implements BackgroundResource {
     this.settings = settings;
     this.stub = ((SpeechStubSettings) settings.getStubSettings()).createStub();
     this.operationsClient =
-        com.google.longrunning.OperationsClient.create(this.stub.getOperationsStub());
+            com.google.longrunning.OperationsClient.create(this.stub.getOperationsStub());
     this.httpJsonOperationsClient = OperationsClient.create(this.stub.getHttpJsonOperationsStub());
   }
 
@@ -162,7 +177,7 @@ public class SpeechClient implements BackgroundResource {
     this.settings = null;
     this.stub = stub;
     this.operationsClient =
-        com.google.longrunning.OperationsClient.create(this.stub.getOperationsStub());
+            com.google.longrunning.OperationsClient.create(this.stub.getOperationsStub());
     this.httpJsonOperationsClient = OperationsClient.create(this.stub.getHttpJsonOperationsStub());
   }
 
@@ -218,7 +233,7 @@ public class SpeechClient implements BackgroundResource {
    */
   public final RecognizeResponse recognize(RecognitionConfig config, RecognitionAudio audio) {
     RecognizeRequest request =
-        RecognizeRequest.newBuilder().setConfig(config).setAudio(audio).build();
+            RecognizeRequest.newBuilder().setConfig(config).setAudio(audio).build();
     return recognize(request);
   }
 
@@ -310,9 +325,9 @@ public class SpeechClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final OperationFuture<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-      longRunningRecognizeAsync(RecognitionConfig config, RecognitionAudio audio) {
+  longRunningRecognizeAsync(RecognitionConfig config, RecognitionAudio audio) {
     LongRunningRecognizeRequest request =
-        LongRunningRecognizeRequest.newBuilder().setConfig(config).setAudio(audio).build();
+            LongRunningRecognizeRequest.newBuilder().setConfig(config).setAudio(audio).build();
     return longRunningRecognizeAsync(request);
   }
 
@@ -346,7 +361,7 @@ public class SpeechClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final OperationFuture<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-      longRunningRecognizeAsync(LongRunningRecognizeRequest request) {
+  longRunningRecognizeAsync(LongRunningRecognizeRequest request) {
     return longRunningRecognizeOperationCallable().futureCall(request);
   }
 
@@ -381,7 +396,7 @@ public class SpeechClient implements BackgroundResource {
    */
   public final OperationCallable<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-      longRunningRecognizeOperationCallable() {
+  longRunningRecognizeOperationCallable() {
     return stub.longRunningRecognizeOperationCallable();
   }
 
@@ -414,7 +429,7 @@ public class SpeechClient implements BackgroundResource {
    * }</pre>
    */
   public final UnaryCallable<LongRunningRecognizeRequest, Operation>
-      longRunningRecognizeCallable() {
+  longRunningRecognizeCallable() {
     return stub.longRunningRecognizeCallable();
   }
 
@@ -443,8 +458,505 @@ public class SpeechClient implements BackgroundResource {
    * }</pre>
    */
   public final BidiStreamingCallable<StreamingRecognizeRequest, StreamingRecognizeResponse>
-      streamingRecognizeCallable() {
+  streamingRecognizeCallable() {
     return stub.streamingRecognizeCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Lists operations that match the specified filter in the request. If the server doesn't support
+   * this method, it returns `UNIMPLEMENTED`.
+   *
+   * <p>NOTE: the `name` binding allows API services to override the binding to use different
+   * resource name schemes, such as `users/&#42;/operations`. To override the binding, API services
+   * can add a binding such as `"/v1/{name=users/&#42;}/operations"` to their service configuration.
+   * For backwards compatibility, the default name includes the operations collection id, however
+   * overriding users must ensure the name binding is the parent resource, without the operations
+   * collection id.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   String name = "name3373707";
+   *   String filter = "filter-1274492040";
+   *   for (Operation element : speechClient.listOperations(name, filter).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param name The name of the operation's parent resource.
+   * @param filter The standard list filter.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListOperationsPagedResponse listOperations(String name, String filter) {
+    ListOperationsRequest request =
+            ListOperationsRequest.newBuilder().setName(name).setFilter(filter).build();
+    return listOperations(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Lists operations that match the specified filter in the request. If the server doesn't support
+   * this method, it returns `UNIMPLEMENTED`.
+   *
+   * <p>NOTE: the `name` binding allows API services to override the binding to use different
+   * resource name schemes, such as `users/&#42;/operations`. To override the binding, API services
+   * can add a binding such as `"/v1/{name=users/&#42;}/operations"` to their service configuration.
+   * For backwards compatibility, the default name includes the operations collection id, however
+   * overriding users must ensure the name binding is the parent resource, without the operations
+   * collection id.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   ListOperationsRequest request =
+   *       ListOperationsRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setFilter("filter-1274492040")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (Operation element : speechClient.listOperations(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListOperationsPagedResponse listOperations(ListOperationsRequest request) {
+    return listOperationsPagedCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Lists operations that match the specified filter in the request. If the server doesn't support
+   * this method, it returns `UNIMPLEMENTED`.
+   *
+   * <p>NOTE: the `name` binding allows API services to override the binding to use different
+   * resource name schemes, such as `users/&#42;/operations`. To override the binding, API services
+   * can add a binding such as `"/v1/{name=users/&#42;}/operations"` to their service configuration.
+   * For backwards compatibility, the default name includes the operations collection id, however
+   * overriding users must ensure the name binding is the parent resource, without the operations
+   * collection id.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   ListOperationsRequest request =
+   *       ListOperationsRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setFilter("filter-1274492040")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   ApiFuture<Operation> future = speechClient.listOperationsPagedCallable().futureCall(request);
+   *   // Do something.
+   *   for (Operation element : future.get().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<ListOperationsRequest, ListOperationsPagedResponse>
+  listOperationsPagedCallable() {
+    return stub.listOperationsPagedCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Lists operations that match the specified filter in the request. If the server doesn't support
+   * this method, it returns `UNIMPLEMENTED`.
+   *
+   * <p>NOTE: the `name` binding allows API services to override the binding to use different
+   * resource name schemes, such as `users/&#42;/operations`. To override the binding, API services
+   * can add a binding such as `"/v1/{name=users/&#42;}/operations"` to their service configuration.
+   * For backwards compatibility, the default name includes the operations collection id, however
+   * overriding users must ensure the name binding is the parent resource, without the operations
+   * collection id.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   ListOperationsRequest request =
+   *       ListOperationsRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setFilter("filter-1274492040")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   while (true) {
+   *     ListOperationsResponse response = speechClient.listOperationsCallable().call(request);
+   *     for (Operation element : response.getOperationsList()) {
+   *       // doThingsWith(element);
+   *     }
+   *     String nextPageToken = response.getNextPageToken();
+   *     if (!Strings.isNullOrEmpty(nextPageToken)) {
+   *       request = request.toBuilder().setPageToken(nextPageToken).build();
+   *     } else {
+   *       break;
+   *     }
+   *   }
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<ListOperationsRequest, ListOperationsResponse>
+  listOperationsCallable() {
+    return stub.listOperationsCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Gets the latest state of a long-running operation. Clients can use this method to poll the
+   * operation result at intervals as recommended by the API service.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   String name = "name3373707";
+   *   Operation response = speechClient.getOperation(name);
+   * }
+   * }</pre>
+   *
+   * @param name The name of the operation resource.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Operation getOperation(String name) {
+    GetOperationRequest request = GetOperationRequest.newBuilder().setName(name).build();
+    return getOperation(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Gets the latest state of a long-running operation. Clients can use this method to poll the
+   * operation result at intervals as recommended by the API service.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   GetOperationRequest request = GetOperationRequest.newBuilder().setName("name3373707").build();
+   *   Operation response = speechClient.getOperation(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Operation getOperation(GetOperationRequest request) {
+    return getOperationCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Gets the latest state of a long-running operation. Clients can use this method to poll the
+   * operation result at intervals as recommended by the API service.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   GetOperationRequest request = GetOperationRequest.newBuilder().setName("name3373707").build();
+   *   ApiFuture<Operation> future = speechClient.getOperationCallable().futureCall(request);
+   *   // Do something.
+   *   Operation response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<GetOperationRequest, Operation> getOperationCallable() {
+    return stub.getOperationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Deletes a long-running operation. This method indicates that the client is no longer interested
+   * in the operation result. It does not cancel the operation. If the server doesn't support this
+   * method, it returns `google.rpc.Code.UNIMPLEMENTED`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   String name = "name3373707";
+   *   speechClient.deleteOperation(name);
+   * }
+   * }</pre>
+   *
+   * @param name The name of the operation resource to be deleted.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void deleteOperation(String name) {
+    DeleteOperationRequest request = DeleteOperationRequest.newBuilder().setName(name).build();
+    deleteOperation(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Deletes a long-running operation. This method indicates that the client is no longer interested
+   * in the operation result. It does not cancel the operation. If the server doesn't support this
+   * method, it returns `google.rpc.Code.UNIMPLEMENTED`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   DeleteOperationRequest request =
+   *       DeleteOperationRequest.newBuilder().setName("name3373707").build();
+   *   speechClient.deleteOperation(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void deleteOperation(DeleteOperationRequest request) {
+    deleteOperationCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Deletes a long-running operation. This method indicates that the client is no longer interested
+   * in the operation result. It does not cancel the operation. If the server doesn't support this
+   * method, it returns `google.rpc.Code.UNIMPLEMENTED`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   DeleteOperationRequest request =
+   *       DeleteOperationRequest.newBuilder().setName("name3373707").build();
+   *   ApiFuture<Empty> future = speechClient.deleteOperationCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<DeleteOperationRequest, Empty> deleteOperationCallable() {
+    return stub.deleteOperationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Starts asynchronous cancellation on a long-running operation. The server makes a best effort to
+   * cancel the operation, but success is not guaranteed. If the server doesn't support this method,
+   * it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use
+   * [Operations.GetOperation][google.longrunning.Operations.GetOperation] or other methods to check
+   * whether the cancellation succeeded or whether the operation completed despite cancellation. On
+   * successful cancellation, the operation is not deleted; instead, it becomes an operation with an
+   * [Operation.error][google.longrunning.Operation.error] value with a
+   * [google.rpc.Status.code][google.rpc.Status.code] of 1, corresponding to `Code.CANCELLED`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   String name = "name3373707";
+   *   speechClient.cancelOperation(name);
+   * }
+   * }</pre>
+   *
+   * @param name The name of the operation resource to be cancelled.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void cancelOperation(String name) {
+    CancelOperationRequest request = CancelOperationRequest.newBuilder().setName(name).build();
+    cancelOperation(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Starts asynchronous cancellation on a long-running operation. The server makes a best effort to
+   * cancel the operation, but success is not guaranteed. If the server doesn't support this method,
+   * it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use
+   * [Operations.GetOperation][google.longrunning.Operations.GetOperation] or other methods to check
+   * whether the cancellation succeeded or whether the operation completed despite cancellation. On
+   * successful cancellation, the operation is not deleted; instead, it becomes an operation with an
+   * [Operation.error][google.longrunning.Operation.error] value with a
+   * [google.rpc.Status.code][google.rpc.Status.code] of 1, corresponding to `Code.CANCELLED`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   CancelOperationRequest request =
+   *       CancelOperationRequest.newBuilder().setName("name3373707").build();
+   *   speechClient.cancelOperation(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void cancelOperation(CancelOperationRequest request) {
+    cancelOperationCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Starts asynchronous cancellation on a long-running operation. The server makes a best effort to
+   * cancel the operation, but success is not guaranteed. If the server doesn't support this method,
+   * it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use
+   * [Operations.GetOperation][google.longrunning.Operations.GetOperation] or other methods to check
+   * whether the cancellation succeeded or whether the operation completed despite cancellation. On
+   * successful cancellation, the operation is not deleted; instead, it becomes an operation with an
+   * [Operation.error][google.longrunning.Operation.error] value with a
+   * [google.rpc.Status.code][google.rpc.Status.code] of 1, corresponding to `Code.CANCELLED`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   CancelOperationRequest request =
+   *       CancelOperationRequest.newBuilder().setName("name3373707").build();
+   *   ApiFuture<Empty> future = speechClient.cancelOperationCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<CancelOperationRequest, Empty> cancelOperationCallable() {
+    return stub.cancelOperationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Waits until the specified long-running operation is done or reaches at most a specified
+   * timeout, returning the latest state. If the operation is already done, the latest state is
+   * immediately returned. If the timeout specified is greater than the default HTTP/RPC timeout,
+   * the HTTP/RPC timeout is used. If the server does not support this method, it returns
+   * `google.rpc.Code.UNIMPLEMENTED`. Note that this method is on a best-effort basis. It may return
+   * the latest state before the specified timeout (including immediately), meaning even an
+   * immediate response is no guarantee that the operation is done.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   WaitOperationRequest request =
+   *       WaitOperationRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setTimeout(Duration.newBuilder().build())
+   *           .build();
+   *   Operation response = speechClient.waitOperation(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Operation waitOperation(WaitOperationRequest request) {
+    return waitOperationCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Waits until the specified long-running operation is done or reaches at most a specified
+   * timeout, returning the latest state. If the operation is already done, the latest state is
+   * immediately returned. If the timeout specified is greater than the default HTTP/RPC timeout,
+   * the HTTP/RPC timeout is used. If the server does not support this method, it returns
+   * `google.rpc.Code.UNIMPLEMENTED`. Note that this method is on a best-effort basis. It may return
+   * the latest state before the specified timeout (including immediately), meaning even an
+   * immediate response is no guarantee that the operation is done.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (SpeechClient speechClient = SpeechClient.create()) {
+   *   WaitOperationRequest request =
+   *       WaitOperationRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setTimeout(Duration.newBuilder().build())
+   *           .build();
+   *   ApiFuture<Operation> future = speechClient.waitOperationCallable().futureCall(request);
+   *   // Do something.
+   *   Operation response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<WaitOperationRequest, Operation> waitOperationCallable() {
+    return stub.waitOperationCallable();
   }
 
   @Override
@@ -475,5 +987,81 @@ public class SpeechClient implements BackgroundResource {
   @Override
   public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
     return stub.awaitTermination(duration, unit);
+  }
+
+  public static class ListOperationsPagedResponse
+          extends AbstractPagedListResponse<
+          ListOperationsRequest,
+          ListOperationsResponse,
+          Operation,
+          ListOperationsPage,
+          ListOperationsFixedSizeCollection> {
+
+    public static ApiFuture<ListOperationsPagedResponse> createAsync(
+            PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
+            ApiFuture<ListOperationsResponse> futureResponse) {
+      ApiFuture<ListOperationsPage> futurePage =
+              ListOperationsPage.createEmptyPage().createPageAsync(context, futureResponse);
+      return ApiFutures.transform(
+              futurePage,
+              input -> new ListOperationsPagedResponse(input),
+              MoreExecutors.directExecutor());
+    }
+
+    private ListOperationsPagedResponse(ListOperationsPage page) {
+      super(page, ListOperationsFixedSizeCollection.createEmptyCollection());
+    }
+  }
+
+  public static class ListOperationsPage
+          extends AbstractPage<
+          ListOperationsRequest, ListOperationsResponse, Operation, ListOperationsPage> {
+
+    private ListOperationsPage(
+            PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
+            ListOperationsResponse response) {
+      super(context, response);
+    }
+
+    private static ListOperationsPage createEmptyPage() {
+      return new ListOperationsPage(null, null);
+    }
+
+    @Override
+    protected ListOperationsPage createPage(
+            PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
+            ListOperationsResponse response) {
+      return new ListOperationsPage(context, response);
+    }
+
+    @Override
+    public ApiFuture<ListOperationsPage> createPageAsync(
+            PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
+            ApiFuture<ListOperationsResponse> futureResponse) {
+      return super.createPageAsync(context, futureResponse);
+    }
+  }
+
+  public static class ListOperationsFixedSizeCollection
+          extends AbstractFixedSizeCollection<
+          ListOperationsRequest,
+          ListOperationsResponse,
+          Operation,
+          ListOperationsPage,
+          ListOperationsFixedSizeCollection> {
+
+    private ListOperationsFixedSizeCollection(List<ListOperationsPage> pages, int collectionSize) {
+      super(pages, collectionSize);
+    }
+
+    private static ListOperationsFixedSizeCollection createEmptyCollection() {
+      return new ListOperationsFixedSizeCollection(null, 0);
+    }
+
+    @Override
+    protected ListOperationsFixedSizeCollection createCollection(
+            List<ListOperationsPage> pages, int collectionSize) {
+      return new ListOperationsFixedSizeCollection(pages, collectionSize);
+    }
   }
 }

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/SpeechClient.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/SpeechClient.java
@@ -169,7 +169,7 @@ public class SpeechClient implements BackgroundResource {
     this.settings = settings;
     this.stub = ((SpeechStubSettings) settings.getStubSettings()).createStub();
     this.operationsClient =
-            com.google.longrunning.OperationsClient.create(this.stub.getOperationsStub());
+        com.google.longrunning.OperationsClient.create(this.stub.getOperationsStub());
     this.httpJsonOperationsClient = OperationsClient.create(this.stub.getHttpJsonOperationsStub());
   }
 
@@ -177,7 +177,7 @@ public class SpeechClient implements BackgroundResource {
     this.settings = null;
     this.stub = stub;
     this.operationsClient =
-            com.google.longrunning.OperationsClient.create(this.stub.getOperationsStub());
+        com.google.longrunning.OperationsClient.create(this.stub.getOperationsStub());
     this.httpJsonOperationsClient = OperationsClient.create(this.stub.getHttpJsonOperationsStub());
   }
 
@@ -233,7 +233,7 @@ public class SpeechClient implements BackgroundResource {
    */
   public final RecognizeResponse recognize(RecognitionConfig config, RecognitionAudio audio) {
     RecognizeRequest request =
-            RecognizeRequest.newBuilder().setConfig(config).setAudio(audio).build();
+        RecognizeRequest.newBuilder().setConfig(config).setAudio(audio).build();
     return recognize(request);
   }
 
@@ -325,9 +325,9 @@ public class SpeechClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final OperationFuture<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-  longRunningRecognizeAsync(RecognitionConfig config, RecognitionAudio audio) {
+      longRunningRecognizeAsync(RecognitionConfig config, RecognitionAudio audio) {
     LongRunningRecognizeRequest request =
-            LongRunningRecognizeRequest.newBuilder().setConfig(config).setAudio(audio).build();
+        LongRunningRecognizeRequest.newBuilder().setConfig(config).setAudio(audio).build();
     return longRunningRecognizeAsync(request);
   }
 
@@ -361,7 +361,7 @@ public class SpeechClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final OperationFuture<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-  longRunningRecognizeAsync(LongRunningRecognizeRequest request) {
+      longRunningRecognizeAsync(LongRunningRecognizeRequest request) {
     return longRunningRecognizeOperationCallable().futureCall(request);
   }
 
@@ -396,7 +396,7 @@ public class SpeechClient implements BackgroundResource {
    */
   public final OperationCallable<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-  longRunningRecognizeOperationCallable() {
+      longRunningRecognizeOperationCallable() {
     return stub.longRunningRecognizeOperationCallable();
   }
 
@@ -429,7 +429,7 @@ public class SpeechClient implements BackgroundResource {
    * }</pre>
    */
   public final UnaryCallable<LongRunningRecognizeRequest, Operation>
-  longRunningRecognizeCallable() {
+      longRunningRecognizeCallable() {
     return stub.longRunningRecognizeCallable();
   }
 
@@ -458,7 +458,7 @@ public class SpeechClient implements BackgroundResource {
    * }</pre>
    */
   public final BidiStreamingCallable<StreamingRecognizeRequest, StreamingRecognizeResponse>
-  streamingRecognizeCallable() {
+      streamingRecognizeCallable() {
     return stub.streamingRecognizeCallable();
   }
 
@@ -497,7 +497,7 @@ public class SpeechClient implements BackgroundResource {
    */
   public final ListOperationsPagedResponse listOperations(String name, String filter) {
     ListOperationsRequest request =
-            ListOperationsRequest.newBuilder().setName(name).setFilter(filter).build();
+        ListOperationsRequest.newBuilder().setName(name).setFilter(filter).build();
     return listOperations(request);
   }
 
@@ -579,7 +579,7 @@ public class SpeechClient implements BackgroundResource {
    * }</pre>
    */
   public final UnaryCallable<ListOperationsRequest, ListOperationsPagedResponse>
-  listOperationsPagedCallable() {
+      listOperationsPagedCallable() {
     return stub.listOperationsPagedCallable();
   }
 
@@ -627,7 +627,7 @@ public class SpeechClient implements BackgroundResource {
    * }</pre>
    */
   public final UnaryCallable<ListOperationsRequest, ListOperationsResponse>
-  listOperationsCallable() {
+      listOperationsCallable() {
     return stub.listOperationsCallable();
   }
 
@@ -990,7 +990,7 @@ public class SpeechClient implements BackgroundResource {
   }
 
   public static class ListOperationsPagedResponse
-          extends AbstractPagedListResponse<
+      extends AbstractPagedListResponse<
           ListOperationsRequest,
           ListOperationsResponse,
           Operation,
@@ -998,14 +998,14 @@ public class SpeechClient implements BackgroundResource {
           ListOperationsFixedSizeCollection> {
 
     public static ApiFuture<ListOperationsPagedResponse> createAsync(
-            PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
-            ApiFuture<ListOperationsResponse> futureResponse) {
+        PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
+        ApiFuture<ListOperationsResponse> futureResponse) {
       ApiFuture<ListOperationsPage> futurePage =
-              ListOperationsPage.createEmptyPage().createPageAsync(context, futureResponse);
+          ListOperationsPage.createEmptyPage().createPageAsync(context, futureResponse);
       return ApiFutures.transform(
-              futurePage,
-              input -> new ListOperationsPagedResponse(input),
-              MoreExecutors.directExecutor());
+          futurePage,
+          input -> new ListOperationsPagedResponse(input),
+          MoreExecutors.directExecutor());
     }
 
     private ListOperationsPagedResponse(ListOperationsPage page) {
@@ -1014,12 +1014,12 @@ public class SpeechClient implements BackgroundResource {
   }
 
   public static class ListOperationsPage
-          extends AbstractPage<
+      extends AbstractPage<
           ListOperationsRequest, ListOperationsResponse, Operation, ListOperationsPage> {
 
     private ListOperationsPage(
-            PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
-            ListOperationsResponse response) {
+        PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
+        ListOperationsResponse response) {
       super(context, response);
     }
 
@@ -1029,21 +1029,21 @@ public class SpeechClient implements BackgroundResource {
 
     @Override
     protected ListOperationsPage createPage(
-            PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
-            ListOperationsResponse response) {
+        PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
+        ListOperationsResponse response) {
       return new ListOperationsPage(context, response);
     }
 
     @Override
     public ApiFuture<ListOperationsPage> createPageAsync(
-            PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
-            ApiFuture<ListOperationsResponse> futureResponse) {
+        PageContext<ListOperationsRequest, ListOperationsResponse, Operation> context,
+        ApiFuture<ListOperationsResponse> futureResponse) {
       return super.createPageAsync(context, futureResponse);
     }
   }
 
   public static class ListOperationsFixedSizeCollection
-          extends AbstractFixedSizeCollection<
+      extends AbstractFixedSizeCollection<
           ListOperationsRequest,
           ListOperationsResponse,
           Operation,
@@ -1060,7 +1060,7 @@ public class SpeechClient implements BackgroundResource {
 
     @Override
     protected ListOperationsFixedSizeCollection createCollection(
-            List<ListOperationsPage> pages, int collectionSize) {
+        List<ListOperationsPage> pages, int collectionSize) {
       return new ListOperationsFixedSizeCollection(pages, collectionSize);
     }
   }

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/HttpJsonAdaptationCallableFactory.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/HttpJsonAdaptationCallableFactory.java
@@ -24,6 +24,7 @@ import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.httpjson.longrunning.stub.OperationsStub;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.LongRunningClient;
 import com.google.api.gax.rpc.OperationCallSettings;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PagedCallSettings;
@@ -91,6 +92,24 @@ public class HttpJsonAdaptationCallableFactory
             httpJsonCallSettings.getMethodDescriptor().getOperationSnapshotFactory());
     return HttpJsonCallableFactory.createOperationCallable(
         callSettings, clientContext, operationsStub.longRunningClient(), initialCallable);
+  }
+
+  @Override
+  public <RequestT, ResponseT, MetadataT>
+      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+          HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings,
+          OperationCallSettings<RequestT, ResponseT, MetadataT> callSettings,
+          ClientContext clientContext,
+          LongRunningClient longRunningClient) {
+    UnaryCallable<RequestT, Operation> innerCallable =
+        HttpJsonCallableFactory.createBaseUnaryCallable(
+            httpJsonCallSettings, callSettings.getInitialCallSettings(), clientContext);
+    HttpJsonOperationSnapshotCallable<RequestT, Operation> initialCallable =
+        new HttpJsonOperationSnapshotCallable<RequestT, Operation>(
+            innerCallable,
+            httpJsonCallSettings.getMethodDescriptor().getOperationSnapshotFactory());
+    return HttpJsonCallableFactory.createOperationCallable(
+        callSettings, clientContext, longRunningClient, initialCallable);
   }
 
   @Override

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/HttpJsonSpeechCallableFactory.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/HttpJsonSpeechCallableFactory.java
@@ -24,6 +24,7 @@ import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.httpjson.longrunning.stub.OperationsStub;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.LongRunningClient;
 import com.google.api.gax.rpc.OperationCallSettings;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PagedCallSettings;
@@ -91,6 +92,24 @@ public class HttpJsonSpeechCallableFactory
             httpJsonCallSettings.getMethodDescriptor().getOperationSnapshotFactory());
     return HttpJsonCallableFactory.createOperationCallable(
         callSettings, clientContext, operationsStub.longRunningClient(), initialCallable);
+  }
+
+  @Override
+  public <RequestT, ResponseT, MetadataT>
+      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+          HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings,
+          OperationCallSettings<RequestT, ResponseT, MetadataT> callSettings,
+          ClientContext clientContext,
+          LongRunningClient longRunningClient) {
+    UnaryCallable<RequestT, Operation> innerCallable =
+        HttpJsonCallableFactory.createBaseUnaryCallable(
+            httpJsonCallSettings, callSettings.getInitialCallSettings(), clientContext);
+    HttpJsonOperationSnapshotCallable<RequestT, Operation> initialCallable =
+        new HttpJsonOperationSnapshotCallable<RequestT, Operation>(
+            innerCallable,
+            httpJsonCallSettings.getMethodDescriptor().getOperationSnapshotFactory());
+    return HttpJsonCallableFactory.createOperationCallable(
+        callSettings, clientContext, longRunningClient, initialCallable);
   }
 
   @Override

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/HttpJsonSpeechStub.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/HttpJsonSpeechStub.java
@@ -32,8 +32,6 @@ import com.google.api.gax.httpjson.ProtoMessageRequestFormatter;
 import com.google.api.gax.httpjson.ProtoMessageResponseParser;
 import com.google.api.gax.httpjson.ProtoRestSerializer;
 import com.google.api.gax.httpjson.longrunning.stub.HttpJsonOperationsStub;
-import com.google.api.gax.httpjson.longrunning.stub.OperationsStubSettings;
-import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.LongRunningClient;
@@ -73,228 +71,228 @@ import javax.annotation.Generated;
 @BetaApi
 public class HttpJsonSpeechStub extends SpeechStub {
   private static final TypeRegistry typeRegistry =
-          TypeRegistry.newBuilder()
-                  .add(LongRunningRecognizeResponse.getDescriptor())
-                  .add(LongRunningRecognizeMetadata.getDescriptor())
-                  .build();
+      TypeRegistry.newBuilder()
+          .add(LongRunningRecognizeResponse.getDescriptor())
+          .add(LongRunningRecognizeMetadata.getDescriptor())
+          .build();
 
   private static final ApiMethodDescriptor<RecognizeRequest, RecognizeResponse>
-          recognizeMethodDescriptor =
+      recognizeMethodDescriptor =
           ApiMethodDescriptor.<RecognizeRequest, RecognizeResponse>newBuilder()
-                  .setFullMethodName("google.cloud.speech.v1.Speech/Recognize")
-                  .setHttpMethod("POST")
-                  .setType(ApiMethodDescriptor.MethodType.UNARY)
-                  .setRequestFormatter(
-                          ProtoMessageRequestFormatter.<RecognizeRequest>newBuilder()
-                                  .setPath(
-                                          "/v1/speech:recognize",
-                                          request -> {
-                                            Map<String, String> fields = new HashMap<>();
-                                            ProtoRestSerializer<RecognizeRequest> serializer =
-                                                    ProtoRestSerializer.create();
-                                            return fields;
-                                          })
-                                  .setQueryParamsExtractor(
-                                          request -> {
-                                            Map<String, List<String>> fields = new HashMap<>();
-                                            ProtoRestSerializer<RecognizeRequest> serializer =
-                                                    ProtoRestSerializer.create();
-                                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
-                                            return fields;
-                                          })
-                                  .setRequestBodyExtractor(
-                                          request ->
-                                                  ProtoRestSerializer.create()
-                                                          .toBody("*", request.toBuilder().build(), true))
-                                  .build())
-                  .setResponseParser(
-                          ProtoMessageResponseParser.<RecognizeResponse>newBuilder()
-                                  .setDefaultInstance(RecognizeResponse.getDefaultInstance())
-                                  .setDefaultTypeRegistry(typeRegistry)
-                                  .build())
-                  .build();
+              .setFullMethodName("google.cloud.speech.v1.Speech/Recognize")
+              .setHttpMethod("POST")
+              .setType(ApiMethodDescriptor.MethodType.UNARY)
+              .setRequestFormatter(
+                  ProtoMessageRequestFormatter.<RecognizeRequest>newBuilder()
+                      .setPath(
+                          "/v1/speech:recognize",
+                          request -> {
+                            Map<String, String> fields = new HashMap<>();
+                            ProtoRestSerializer<RecognizeRequest> serializer =
+                                ProtoRestSerializer.create();
+                            return fields;
+                          })
+                      .setQueryParamsExtractor(
+                          request -> {
+                            Map<String, List<String>> fields = new HashMap<>();
+                            ProtoRestSerializer<RecognizeRequest> serializer =
+                                ProtoRestSerializer.create();
+                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
+                            return fields;
+                          })
+                      .setRequestBodyExtractor(
+                          request ->
+                              ProtoRestSerializer.create()
+                                  .toBody("*", request.toBuilder().build(), true))
+                      .build())
+              .setResponseParser(
+                  ProtoMessageResponseParser.<RecognizeResponse>newBuilder()
+                      .setDefaultInstance(RecognizeResponse.getDefaultInstance())
+                      .setDefaultTypeRegistry(typeRegistry)
+                      .build())
+              .build();
 
   private static final ApiMethodDescriptor<LongRunningRecognizeRequest, Operation>
-          longRunningRecognizeMethodDescriptor =
+      longRunningRecognizeMethodDescriptor =
           ApiMethodDescriptor.<LongRunningRecognizeRequest, Operation>newBuilder()
-                  .setFullMethodName("google.cloud.speech.v1.Speech/LongRunningRecognize")
-                  .setHttpMethod("POST")
-                  .setType(ApiMethodDescriptor.MethodType.UNARY)
-                  .setRequestFormatter(
-                          ProtoMessageRequestFormatter.<LongRunningRecognizeRequest>newBuilder()
-                                  .setPath(
-                                          "/v1/speech:longrunningrecognize",
-                                          request -> {
-                                            Map<String, String> fields = new HashMap<>();
-                                            ProtoRestSerializer<LongRunningRecognizeRequest> serializer =
-                                                    ProtoRestSerializer.create();
-                                            return fields;
-                                          })
-                                  .setQueryParamsExtractor(
-                                          request -> {
-                                            Map<String, List<String>> fields = new HashMap<>();
-                                            ProtoRestSerializer<LongRunningRecognizeRequest> serializer =
-                                                    ProtoRestSerializer.create();
-                                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
-                                            return fields;
-                                          })
-                                  .setRequestBodyExtractor(
-                                          request ->
-                                                  ProtoRestSerializer.create()
-                                                          .toBody("*", request.toBuilder().build(), true))
-                                  .build())
-                  .setResponseParser(
-                          ProtoMessageResponseParser.<Operation>newBuilder()
-                                  .setDefaultInstance(Operation.getDefaultInstance())
-                                  .setDefaultTypeRegistry(typeRegistry)
-                                  .build())
-                  .setOperationSnapshotFactory(
-                          (LongRunningRecognizeRequest request, Operation response) ->
-                                  HttpJsonOperationSnapshot.create(response))
-                  .build();
+              .setFullMethodName("google.cloud.speech.v1.Speech/LongRunningRecognize")
+              .setHttpMethod("POST")
+              .setType(ApiMethodDescriptor.MethodType.UNARY)
+              .setRequestFormatter(
+                  ProtoMessageRequestFormatter.<LongRunningRecognizeRequest>newBuilder()
+                      .setPath(
+                          "/v1/speech:longrunningrecognize",
+                          request -> {
+                            Map<String, String> fields = new HashMap<>();
+                            ProtoRestSerializer<LongRunningRecognizeRequest> serializer =
+                                ProtoRestSerializer.create();
+                            return fields;
+                          })
+                      .setQueryParamsExtractor(
+                          request -> {
+                            Map<String, List<String>> fields = new HashMap<>();
+                            ProtoRestSerializer<LongRunningRecognizeRequest> serializer =
+                                ProtoRestSerializer.create();
+                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
+                            return fields;
+                          })
+                      .setRequestBodyExtractor(
+                          request ->
+                              ProtoRestSerializer.create()
+                                  .toBody("*", request.toBuilder().build(), true))
+                      .build())
+              .setResponseParser(
+                  ProtoMessageResponseParser.<Operation>newBuilder()
+                      .setDefaultInstance(Operation.getDefaultInstance())
+                      .setDefaultTypeRegistry(typeRegistry)
+                      .build())
+              .setOperationSnapshotFactory(
+                  (LongRunningRecognizeRequest request, Operation response) ->
+                      HttpJsonOperationSnapshot.create(response))
+              .build();
 
   private static final ApiMethodDescriptor<ListOperationsRequest, ListOperationsResponse>
-          listOperationsMethodDescriptor =
+      listOperationsMethodDescriptor =
           ApiMethodDescriptor.<ListOperationsRequest, ListOperationsResponse>newBuilder()
-                  .setFullMethodName("google.longrunning.Operations/ListOperations")
-                  .setHttpMethod("GET")
-                  .setType(ApiMethodDescriptor.MethodType.UNARY)
-                  .setRequestFormatter(
-                          ProtoMessageRequestFormatter.<ListOperationsRequest>newBuilder()
-                                  .setPath(
-                                          "/v1/operations",
-                                          request -> {
-                                            Map<String, String> fields = new HashMap<>();
-                                            ProtoRestSerializer<ListOperationsRequest> serializer =
-                                                    ProtoRestSerializer.create();
-                                            return fields;
-                                          })
-                                  .setQueryParamsExtractor(
-                                          request -> {
-                                            Map<String, List<String>> fields = new HashMap<>();
-                                            ProtoRestSerializer<ListOperationsRequest> serializer =
-                                                    ProtoRestSerializer.create();
-                                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
-                                            return fields;
-                                          })
-                                  .setRequestBodyExtractor(request -> null)
-                                  .build())
-                  .setResponseParser(
-                          ProtoMessageResponseParser.<ListOperationsResponse>newBuilder()
-                                  .setDefaultInstance(ListOperationsResponse.getDefaultInstance())
-                                  .setDefaultTypeRegistry(typeRegistry)
-                                  .build())
-                  .build();
+              .setFullMethodName("google.longrunning.Operations/ListOperations")
+              .setHttpMethod("GET")
+              .setType(ApiMethodDescriptor.MethodType.UNARY)
+              .setRequestFormatter(
+                  ProtoMessageRequestFormatter.<ListOperationsRequest>newBuilder()
+                      .setPath(
+                          "/v1/operations",
+                          request -> {
+                            Map<String, String> fields = new HashMap<>();
+                            ProtoRestSerializer<ListOperationsRequest> serializer =
+                                ProtoRestSerializer.create();
+                            return fields;
+                          })
+                      .setQueryParamsExtractor(
+                          request -> {
+                            Map<String, List<String>> fields = new HashMap<>();
+                            ProtoRestSerializer<ListOperationsRequest> serializer =
+                                ProtoRestSerializer.create();
+                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
+                            return fields;
+                          })
+                      .setRequestBodyExtractor(request -> null)
+                      .build())
+              .setResponseParser(
+                  ProtoMessageResponseParser.<ListOperationsResponse>newBuilder()
+                      .setDefaultInstance(ListOperationsResponse.getDefaultInstance())
+                      .setDefaultTypeRegistry(typeRegistry)
+                      .build())
+              .build();
 
   private static final ApiMethodDescriptor<GetOperationRequest, Operation>
-          getOperationMethodDescriptor =
+      getOperationMethodDescriptor =
           ApiMethodDescriptor.<GetOperationRequest, Operation>newBuilder()
-                  .setFullMethodName("google.longrunning.Operations/GetOperation")
-                  .setHttpMethod(HttpMethods.GET)
-                  .setRequestFormatter(
-                          ProtoMessageRequestFormatter.<GetOperationRequest>newBuilder()
-                                  .setPath(
-                                          "/v1/operations/{name=**}",
-                                          request -> {
-                                            Map<String, String> fields = new HashMap<>();
-                                            ProtoRestSerializer<GetOperationRequest> serializer =
-                                                    ProtoRestSerializer.create();
-                                            serializer.putPathParam(fields, "name", request.getName());
-                                            return fields;
-                                          })
-                                  .setQueryParamsExtractor(request -> new HashMap<>())
-                                  .setRequestBodyExtractor(request -> null)
-                                  .build())
-                  .setResponseParser(
-                          ProtoMessageResponseParser.<Operation>newBuilder()
-                                  .setDefaultInstance(Operation.getDefaultInstance())
-                                  .build())
-                  .setOperationSnapshotFactory(
-                          (request, response) -> HttpJsonOperationSnapshot.create(response))
-                  .setPollingRequestFactory(
-                          compoundOperationId ->
-                                  GetOperationRequest.newBuilder().setName(compoundOperationId).build())
-                  .build();
+              .setFullMethodName("google.longrunning.Operations/GetOperation")
+              .setHttpMethod(HttpMethods.GET)
+              .setRequestFormatter(
+                  ProtoMessageRequestFormatter.<GetOperationRequest>newBuilder()
+                      .setPath(
+                          "/v1/operations/{name=**}",
+                          request -> {
+                            Map<String, String> fields = new HashMap<>();
+                            ProtoRestSerializer<GetOperationRequest> serializer =
+                                ProtoRestSerializer.create();
+                            serializer.putPathParam(fields, "name", request.getName());
+                            return fields;
+                          })
+                      .setQueryParamsExtractor(request -> new HashMap<>())
+                      .setRequestBodyExtractor(request -> null)
+                      .build())
+              .setResponseParser(
+                  ProtoMessageResponseParser.<Operation>newBuilder()
+                      .setDefaultInstance(Operation.getDefaultInstance())
+                      .build())
+              .setOperationSnapshotFactory(
+                  (request, response) -> HttpJsonOperationSnapshot.create(response))
+              .setPollingRequestFactory(
+                  compoundOperationId ->
+                      GetOperationRequest.newBuilder().setName(compoundOperationId).build())
+              .build();
 
   private static final ApiMethodDescriptor<DeleteOperationRequest, Empty>
-          deleteOperationMethodDescriptor =
+      deleteOperationMethodDescriptor =
           ApiMethodDescriptor.<DeleteOperationRequest, Empty>newBuilder()
-                  .setFullMethodName("google.longrunning.Operations/DeleteOperation")
-                  .setHttpMethod("DELETE")
-                  .setType(ApiMethodDescriptor.MethodType.UNARY)
-                  .setRequestFormatter(
-                          ProtoMessageRequestFormatter.<DeleteOperationRequest>newBuilder()
-                                  .setPath(
-                                          "/v1/{name=operations/**}",
-                                          request -> {
-                                            Map<String, String> fields = new HashMap<>();
-                                            ProtoRestSerializer<DeleteOperationRequest> serializer =
-                                                    ProtoRestSerializer.create();
-                                            serializer.putPathParam(fields, "name", request.getName());
-                                            return fields;
-                                          })
-                                  .setQueryParamsExtractor(
-                                          request -> {
-                                            Map<String, List<String>> fields = new HashMap<>();
-                                            ProtoRestSerializer<DeleteOperationRequest> serializer =
-                                                    ProtoRestSerializer.create();
-                                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
-                                            return fields;
-                                          })
-                                  .setRequestBodyExtractor(request -> null)
-                                  .build())
-                  .setResponseParser(
-                          ProtoMessageResponseParser.<Empty>newBuilder()
-                                  .setDefaultInstance(Empty.getDefaultInstance())
-                                  .setDefaultTypeRegistry(typeRegistry)
-                                  .build())
-                  .build();
+              .setFullMethodName("google.longrunning.Operations/DeleteOperation")
+              .setHttpMethod("DELETE")
+              .setType(ApiMethodDescriptor.MethodType.UNARY)
+              .setRequestFormatter(
+                  ProtoMessageRequestFormatter.<DeleteOperationRequest>newBuilder()
+                      .setPath(
+                          "/v1/{name=operations/**}",
+                          request -> {
+                            Map<String, String> fields = new HashMap<>();
+                            ProtoRestSerializer<DeleteOperationRequest> serializer =
+                                ProtoRestSerializer.create();
+                            serializer.putPathParam(fields, "name", request.getName());
+                            return fields;
+                          })
+                      .setQueryParamsExtractor(
+                          request -> {
+                            Map<String, List<String>> fields = new HashMap<>();
+                            ProtoRestSerializer<DeleteOperationRequest> serializer =
+                                ProtoRestSerializer.create();
+                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
+                            return fields;
+                          })
+                      .setRequestBodyExtractor(request -> null)
+                      .build())
+              .setResponseParser(
+                  ProtoMessageResponseParser.<Empty>newBuilder()
+                      .setDefaultInstance(Empty.getDefaultInstance())
+                      .setDefaultTypeRegistry(typeRegistry)
+                      .build())
+              .build();
 
   private static final ApiMethodDescriptor<CancelOperationRequest, Empty>
-          cancelOperationMethodDescriptor =
+      cancelOperationMethodDescriptor =
           ApiMethodDescriptor.<CancelOperationRequest, Empty>newBuilder()
-                  .setFullMethodName("google.longrunning.Operations/CancelOperation")
-                  .setHttpMethod("POST")
-                  .setType(ApiMethodDescriptor.MethodType.UNARY)
-                  .setRequestFormatter(
-                          ProtoMessageRequestFormatter.<CancelOperationRequest>newBuilder()
-                                  .setPath(
-                                          "/v1/{name=operations/**}:cancel",
-                                          request -> {
-                                            Map<String, String> fields = new HashMap<>();
-                                            ProtoRestSerializer<CancelOperationRequest> serializer =
-                                                    ProtoRestSerializer.create();
-                                            serializer.putPathParam(fields, "name", request.getName());
-                                            return fields;
-                                          })
-                                  .setQueryParamsExtractor(
-                                          request -> {
-                                            Map<String, List<String>> fields = new HashMap<>();
-                                            ProtoRestSerializer<CancelOperationRequest> serializer =
-                                                    ProtoRestSerializer.create();
-                                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
-                                            return fields;
-                                          })
-                                  .setRequestBodyExtractor(
-                                          request ->
-                                                  ProtoRestSerializer.create()
-                                                          .toBody("*", request.toBuilder().clearName().build(), true))
-                                  .build())
-                  .setResponseParser(
-                          ProtoMessageResponseParser.<Empty>newBuilder()
-                                  .setDefaultInstance(Empty.getDefaultInstance())
-                                  .setDefaultTypeRegistry(typeRegistry)
-                                  .build())
-                  .build();
+              .setFullMethodName("google.longrunning.Operations/CancelOperation")
+              .setHttpMethod("POST")
+              .setType(ApiMethodDescriptor.MethodType.UNARY)
+              .setRequestFormatter(
+                  ProtoMessageRequestFormatter.<CancelOperationRequest>newBuilder()
+                      .setPath(
+                          "/v1/{name=operations/**}:cancel",
+                          request -> {
+                            Map<String, String> fields = new HashMap<>();
+                            ProtoRestSerializer<CancelOperationRequest> serializer =
+                                ProtoRestSerializer.create();
+                            serializer.putPathParam(fields, "name", request.getName());
+                            return fields;
+                          })
+                      .setQueryParamsExtractor(
+                          request -> {
+                            Map<String, List<String>> fields = new HashMap<>();
+                            ProtoRestSerializer<CancelOperationRequest> serializer =
+                                ProtoRestSerializer.create();
+                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
+                            return fields;
+                          })
+                      .setRequestBodyExtractor(
+                          request ->
+                              ProtoRestSerializer.create()
+                                  .toBody("*", request.toBuilder().clearName().build(), true))
+                      .build())
+              .setResponseParser(
+                  ProtoMessageResponseParser.<Empty>newBuilder()
+                      .setDefaultInstance(Empty.getDefaultInstance())
+                      .setDefaultTypeRegistry(typeRegistry)
+                      .build())
+              .build();
 
   private final UnaryCallable<RecognizeRequest, RecognizeResponse> recognizeCallable;
   private final UnaryCallable<LongRunningRecognizeRequest, Operation> longRunningRecognizeCallable;
   private final OperationCallable<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-          longRunningRecognizeOperationCallable;
+      longRunningRecognizeOperationCallable;
   private final UnaryCallable<ListOperationsRequest, ListOperationsResponse> listOperationsCallable;
   private final UnaryCallable<ListOperationsRequest, ListOperationsPagedResponse>
-          listOperationsPagedCallable;
+      listOperationsPagedCallable;
   private final UnaryCallable<GetOperationRequest, Operation> getOperationCallable;
   private final UnaryCallable<DeleteOperationRequest, Empty> deleteOperationCallable;
   private final UnaryCallable<CancelOperationRequest, Empty> cancelOperationCallable;
@@ -312,9 +310,9 @@ public class HttpJsonSpeechStub extends SpeechStub {
   }
 
   public static final HttpJsonSpeechStub create(
-          ClientContext clientContext, HttpJsonStubCallableFactory callableFactory) throws IOException {
+      ClientContext clientContext, HttpJsonStubCallableFactory callableFactory) throws IOException {
     return new HttpJsonSpeechStub(
-            SpeechStubSettings.newHttpJsonBuilder().build(), clientContext, callableFactory);
+        SpeechStubSettings.newHttpJsonBuilder().build(), clientContext, callableFactory);
   }
 
   /**
@@ -323,7 +321,7 @@ public class HttpJsonSpeechStub extends SpeechStub {
    * preferred.
    */
   protected HttpJsonSpeechStub(SpeechStubSettings settings, ClientContext clientContext)
-          throws IOException {
+      throws IOException {
     this(settings, clientContext, new HttpJsonSpeechCallableFactory());
   }
 
@@ -333,83 +331,87 @@ public class HttpJsonSpeechStub extends SpeechStub {
    * preferred.
    */
   protected HttpJsonSpeechStub(
-          SpeechStubSettings settings,
-          ClientContext clientContext,
-          HttpJsonStubCallableFactory callableFactory)
-          throws IOException {
+      SpeechStubSettings settings,
+      ClientContext clientContext,
+      HttpJsonStubCallableFactory callableFactory)
+      throws IOException {
     this.callableFactory = callableFactory;
     HttpJsonOperationsStub httpJsonOperationsStub =
         HttpJsonOperationsStub.create(clientContext, callableFactory, typeRegistry);
 
     HttpJsonCallSettings<ListOperationsRequest, ListOperationsResponse>
-            listOperationsTransportSettings =
+        listOperationsTransportSettings =
             HttpJsonCallSettings.<ListOperationsRequest, ListOperationsResponse>newBuilder()
-                    .setMethodDescriptor(listOperationsMethodDescriptor)
-                    .setTypeRegistry(typeRegistry)
-                    .build();
+                .setMethodDescriptor(listOperationsMethodDescriptor)
+                .setTypeRegistry(typeRegistry)
+                .build();
     HttpJsonCallSettings<GetOperationRequest, Operation> getOperationTransportSettings =
-            HttpJsonCallSettings.<GetOperationRequest, Operation>newBuilder()
-                    .setMethodDescriptor(getOperationMethodDescriptor)
-                    .setTypeRegistry(typeRegistry)
-                    .build();
+        HttpJsonCallSettings.<GetOperationRequest, Operation>newBuilder()
+            .setMethodDescriptor(getOperationMethodDescriptor)
+            .setTypeRegistry(typeRegistry)
+            .build();
     HttpJsonCallSettings<DeleteOperationRequest, Empty> deleteOperationTransportSettings =
-            HttpJsonCallSettings.<DeleteOperationRequest, Empty>newBuilder()
-                    .setMethodDescriptor(deleteOperationMethodDescriptor)
-                    .setTypeRegistry(typeRegistry)
-                    .build();
+        HttpJsonCallSettings.<DeleteOperationRequest, Empty>newBuilder()
+            .setMethodDescriptor(deleteOperationMethodDescriptor)
+            .setTypeRegistry(typeRegistry)
+            .build();
     HttpJsonCallSettings<CancelOperationRequest, Empty> cancelOperationTransportSettings =
-            HttpJsonCallSettings.<CancelOperationRequest, Empty>newBuilder()
-                    .setMethodDescriptor(cancelOperationMethodDescriptor)
-                    .setTypeRegistry(typeRegistry)
-                    .build();
+        HttpJsonCallSettings.<CancelOperationRequest, Empty>newBuilder()
+            .setMethodDescriptor(cancelOperationMethodDescriptor)
+            .setTypeRegistry(typeRegistry)
+            .build();
 
     this.listOperationsCallable =
-            callableFactory.createUnaryCallable(
-                    listOperationsTransportSettings, settings.listOperationsSettings(), clientContext);
+        callableFactory.createUnaryCallable(
+            listOperationsTransportSettings, settings.listOperationsSettings(), clientContext);
     this.listOperationsPagedCallable =
-            callableFactory.createPagedCallable(
-                    listOperationsTransportSettings, settings.listOperationsSettings(), clientContext);
+        callableFactory.createPagedCallable(
+            listOperationsTransportSettings, settings.listOperationsSettings(), clientContext);
     this.getOperationCallable =
-            callableFactory.createUnaryCallable(
-                    getOperationTransportSettings, settings.getOperationSettings(), clientContext);
+        callableFactory.createUnaryCallable(
+            getOperationTransportSettings, settings.getOperationSettings(), clientContext);
     this.deleteOperationCallable =
-            callableFactory.createUnaryCallable(
-                    deleteOperationTransportSettings, settings.deleteOperationSettings(), clientContext);
+        callableFactory.createUnaryCallable(
+            deleteOperationTransportSettings, settings.deleteOperationSettings(), clientContext);
     this.cancelOperationCallable =
-            callableFactory.createUnaryCallable(
-                    cancelOperationTransportSettings, settings.cancelOperationSettings(), clientContext);
+        callableFactory.createUnaryCallable(
+            cancelOperationTransportSettings, settings.cancelOperationSettings(), clientContext);
 
-    LongRunningClient longRunningClient = new HttpJsonLongRunningClient(this.getOperationCallable, getOperationMethodDescriptor.getOperationSnapshotFactory(), getOperationMethodDescriptor.getPollingRequestFactory());
+    LongRunningClient longRunningClient =
+        new HttpJsonLongRunningClient(
+            this.getOperationCallable,
+            getOperationMethodDescriptor.getOperationSnapshotFactory(),
+            getOperationMethodDescriptor.getPollingRequestFactory());
 
     HttpJsonCallSettings<RecognizeRequest, RecognizeResponse> recognizeTransportSettings =
-            HttpJsonCallSettings.<RecognizeRequest, RecognizeResponse>newBuilder()
-                    .setMethodDescriptor(recognizeMethodDescriptor)
-                    .setTypeRegistry(typeRegistry)
-                    .build();
+        HttpJsonCallSettings.<RecognizeRequest, RecognizeResponse>newBuilder()
+            .setMethodDescriptor(recognizeMethodDescriptor)
+            .setTypeRegistry(typeRegistry)
+            .build();
     HttpJsonCallSettings<LongRunningRecognizeRequest, Operation>
-            longRunningRecognizeTransportSettings =
+        longRunningRecognizeTransportSettings =
             HttpJsonCallSettings.<LongRunningRecognizeRequest, Operation>newBuilder()
-                    .setMethodDescriptor(longRunningRecognizeMethodDescriptor)
-                    .setTypeRegistry(typeRegistry)
-                    .build();
+                .setMethodDescriptor(longRunningRecognizeMethodDescriptor)
+                .setTypeRegistry(typeRegistry)
+                .build();
 
     this.recognizeCallable =
-            callableFactory.createUnaryCallable(
-                    recognizeTransportSettings, settings.recognizeSettings(), clientContext);
+        callableFactory.createUnaryCallable(
+            recognizeTransportSettings, settings.recognizeSettings(), clientContext);
     this.longRunningRecognizeCallable =
-            callableFactory.createUnaryCallable(
-                    longRunningRecognizeTransportSettings,
-                    settings.longRunningRecognizeSettings(),
-                    clientContext);
+        callableFactory.createUnaryCallable(
+            longRunningRecognizeTransportSettings,
+            settings.longRunningRecognizeSettings(),
+            clientContext);
     this.longRunningRecognizeOperationCallable =
-            callableFactory.createOperationCallable(
-                    longRunningRecognizeTransportSettings,
-                    settings.longRunningRecognizeOperationSettings(),
-                    clientContext,
-                    longRunningClient);
+        callableFactory.createOperationCallable(
+            longRunningRecognizeTransportSettings,
+            settings.longRunningRecognizeOperationSettings(),
+            clientContext,
+            longRunningClient);
 
     this.backgroundResources =
-            new BackgroundResourceAggregation(clientContext.getBackgroundResources());
+        new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
 
   @InternalApi
@@ -424,9 +426,9 @@ public class HttpJsonSpeechStub extends SpeechStub {
     return methodDescriptors;
   }
 
-//  public HttpJsonOperationsStub getHttpJsonOperationsStub() {
-//    return httpJsonOperationsStub;
-//  }
+  //  public HttpJsonOperationsStub getHttpJsonOperationsStub() {
+  //    return httpJsonOperationsStub;
+  //  }
 
   @Override
   public UnaryCallable<RecognizeRequest, RecognizeResponse> recognizeCallable() {
@@ -441,7 +443,7 @@ public class HttpJsonSpeechStub extends SpeechStub {
   @Override
   public OperationCallable<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-  longRunningRecognizeOperationCallable() {
+      longRunningRecognizeOperationCallable() {
     return longRunningRecognizeOperationCallable;
   }
 
@@ -452,7 +454,7 @@ public class HttpJsonSpeechStub extends SpeechStub {
 
   @Override
   public UnaryCallable<ListOperationsRequest, ListOperationsPagedResponse>
-  listOperationsPagedCallable() {
+      listOperationsPagedCallable() {
     return listOperationsPagedCallable;
   }
 
@@ -473,15 +475,15 @@ public class HttpJsonSpeechStub extends SpeechStub {
 
   @Override
   public BidiStreamingCallable<StreamingRecognizeRequest, StreamingRecognizeResponse>
-  streamingRecognizeCallable() {
+      streamingRecognizeCallable() {
     throw new UnsupportedOperationException(
-            "Not implemented: streamingRecognizeCallable(). REST transport is not implemented for this method yet.");
+        "Not implemented: streamingRecognizeCallable(). REST transport is not implemented for this method yet.");
   }
 
   @Override
   public UnaryCallable<WaitOperationRequest, Operation> waitOperationCallable() {
     throw new UnsupportedOperationException(
-            "Not implemented: waitOperationCallable(). REST transport is not implemented for this method yet.");
+        "Not implemented: waitOperationCallable(). REST transport is not implemented for this method yet.");
   }
 
   @Override

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/HttpJsonSpeechStub.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/HttpJsonSpeechStub.java
@@ -365,19 +365,19 @@ public class HttpJsonSpeechStub extends SpeechStub {
 
     this.listOperationsCallable =
             callableFactory.createUnaryCallable(
-                    listOperationsTransportSettings, OperationsStubSettings.newBuilder().build().listOperationsSettings(), clientContext);
+                    listOperationsTransportSettings, settings.listOperationsSettings(), clientContext);
     this.listOperationsPagedCallable =
             callableFactory.createPagedCallable(
-                    listOperationsTransportSettings, OperationsStubSettings.newBuilder().build().listOperationsSettings(), clientContext);
+                    listOperationsTransportSettings, settings.listOperationsSettings(), clientContext);
     this.getOperationCallable =
             callableFactory.createUnaryCallable(
-                    getOperationTransportSettings, OperationsStubSettings.newBuilder().build().getOperationSettings(), clientContext);
+                    getOperationTransportSettings, settings.getOperationSettings(), clientContext);
     this.deleteOperationCallable =
             callableFactory.createUnaryCallable(
-                    deleteOperationTransportSettings, OperationsStubSettings.newBuilder().build().deleteOperationSettings(), clientContext);
+                    deleteOperationTransportSettings, settings.deleteOperationSettings(), clientContext);
     this.cancelOperationCallable =
             callableFactory.createUnaryCallable(
-                    cancelOperationTransportSettings, OperationsStubSettings.newBuilder().build().cancelOperationSettings(), clientContext);
+                    cancelOperationTransportSettings, settings.cancelOperationSettings(), clientContext);
 
     LongRunningClient longRunningClient = new HttpJsonLongRunningClient(this.getOperationCallable, getOperationMethodDescriptor.getOperationSnapshotFactory(), getOperationMethodDescriptor.getPollingRequestFactory());
 

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/HttpJsonSpeechStub.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/HttpJsonSpeechStub.java
@@ -16,20 +16,27 @@
 
 package com.google.cloud.speech.v1.stub;
 
+import static com.google.cloud.speech.v1.SpeechClient.ListOperationsPagedResponse;
+
+import com.google.api.client.http.HttpMethods;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
+import com.google.api.gax.httpjson.HttpJsonLongRunningClient;
 import com.google.api.gax.httpjson.HttpJsonOperationSnapshot;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.httpjson.ProtoMessageRequestFormatter;
 import com.google.api.gax.httpjson.ProtoMessageResponseParser;
 import com.google.api.gax.httpjson.ProtoRestSerializer;
 import com.google.api.gax.httpjson.longrunning.stub.HttpJsonOperationsStub;
+import com.google.api.gax.httpjson.longrunning.stub.OperationsStubSettings;
+import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.LongRunningClient;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.speech.v1.LongRunningRecognizeMetadata;
@@ -39,7 +46,14 @@ import com.google.cloud.speech.v1.RecognizeRequest;
 import com.google.cloud.speech.v1.RecognizeResponse;
 import com.google.cloud.speech.v1.StreamingRecognizeRequest;
 import com.google.cloud.speech.v1.StreamingRecognizeResponse;
+import com.google.longrunning.CancelOperationRequest;
+import com.google.longrunning.DeleteOperationRequest;
+import com.google.longrunning.GetOperationRequest;
+import com.google.longrunning.ListOperationsRequest;
+import com.google.longrunning.ListOperationsResponse;
 import com.google.longrunning.Operation;
+import com.google.longrunning.WaitOperationRequest;
+import com.google.protobuf.Empty;
 import com.google.protobuf.TypeRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,94 +73,234 @@ import javax.annotation.Generated;
 @BetaApi
 public class HttpJsonSpeechStub extends SpeechStub {
   private static final TypeRegistry typeRegistry =
-      TypeRegistry.newBuilder()
-          .add(LongRunningRecognizeResponse.getDescriptor())
-          .add(LongRunningRecognizeMetadata.getDescriptor())
-          .build();
+          TypeRegistry.newBuilder()
+                  .add(LongRunningRecognizeResponse.getDescriptor())
+                  .add(LongRunningRecognizeMetadata.getDescriptor())
+                  .build();
 
   private static final ApiMethodDescriptor<RecognizeRequest, RecognizeResponse>
-      recognizeMethodDescriptor =
+          recognizeMethodDescriptor =
           ApiMethodDescriptor.<RecognizeRequest, RecognizeResponse>newBuilder()
-              .setFullMethodName("google.cloud.speech.v1.Speech/Recognize")
-              .setHttpMethod("POST")
-              .setType(ApiMethodDescriptor.MethodType.UNARY)
-              .setRequestFormatter(
-                  ProtoMessageRequestFormatter.<RecognizeRequest>newBuilder()
-                      .setPath(
-                          "/v1/speech:recognize",
-                          request -> {
-                            Map<String, String> fields = new HashMap<>();
-                            ProtoRestSerializer<RecognizeRequest> serializer =
-                                ProtoRestSerializer.create();
-                            return fields;
-                          })
-                      .setQueryParamsExtractor(
-                          request -> {
-                            Map<String, List<String>> fields = new HashMap<>();
-                            ProtoRestSerializer<RecognizeRequest> serializer =
-                                ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
-                            return fields;
-                          })
-                      .setRequestBodyExtractor(
-                          request ->
-                              ProtoRestSerializer.create()
-                                  .toBody("*", request.toBuilder().build(), true))
-                      .build())
-              .setResponseParser(
-                  ProtoMessageResponseParser.<RecognizeResponse>newBuilder()
-                      .setDefaultInstance(RecognizeResponse.getDefaultInstance())
-                      .setDefaultTypeRegistry(typeRegistry)
-                      .build())
-              .build();
+                  .setFullMethodName("google.cloud.speech.v1.Speech/Recognize")
+                  .setHttpMethod("POST")
+                  .setType(ApiMethodDescriptor.MethodType.UNARY)
+                  .setRequestFormatter(
+                          ProtoMessageRequestFormatter.<RecognizeRequest>newBuilder()
+                                  .setPath(
+                                          "/v1/speech:recognize",
+                                          request -> {
+                                            Map<String, String> fields = new HashMap<>();
+                                            ProtoRestSerializer<RecognizeRequest> serializer =
+                                                    ProtoRestSerializer.create();
+                                            return fields;
+                                          })
+                                  .setQueryParamsExtractor(
+                                          request -> {
+                                            Map<String, List<String>> fields = new HashMap<>();
+                                            ProtoRestSerializer<RecognizeRequest> serializer =
+                                                    ProtoRestSerializer.create();
+                                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
+                                            return fields;
+                                          })
+                                  .setRequestBodyExtractor(
+                                          request ->
+                                                  ProtoRestSerializer.create()
+                                                          .toBody("*", request.toBuilder().build(), true))
+                                  .build())
+                  .setResponseParser(
+                          ProtoMessageResponseParser.<RecognizeResponse>newBuilder()
+                                  .setDefaultInstance(RecognizeResponse.getDefaultInstance())
+                                  .setDefaultTypeRegistry(typeRegistry)
+                                  .build())
+                  .build();
 
   private static final ApiMethodDescriptor<LongRunningRecognizeRequest, Operation>
-      longRunningRecognizeMethodDescriptor =
+          longRunningRecognizeMethodDescriptor =
           ApiMethodDescriptor.<LongRunningRecognizeRequest, Operation>newBuilder()
-              .setFullMethodName("google.cloud.speech.v1.Speech/LongRunningRecognize")
-              .setHttpMethod("POST")
-              .setType(ApiMethodDescriptor.MethodType.UNARY)
-              .setRequestFormatter(
-                  ProtoMessageRequestFormatter.<LongRunningRecognizeRequest>newBuilder()
-                      .setPath(
-                          "/v1/speech:longrunningrecognize",
-                          request -> {
-                            Map<String, String> fields = new HashMap<>();
-                            ProtoRestSerializer<LongRunningRecognizeRequest> serializer =
-                                ProtoRestSerializer.create();
-                            return fields;
-                          })
-                      .setQueryParamsExtractor(
-                          request -> {
-                            Map<String, List<String>> fields = new HashMap<>();
-                            ProtoRestSerializer<LongRunningRecognizeRequest> serializer =
-                                ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
-                            return fields;
-                          })
-                      .setRequestBodyExtractor(
-                          request ->
-                              ProtoRestSerializer.create()
-                                  .toBody("*", request.toBuilder().build(), true))
-                      .build())
-              .setResponseParser(
-                  ProtoMessageResponseParser.<Operation>newBuilder()
-                      .setDefaultInstance(Operation.getDefaultInstance())
-                      .setDefaultTypeRegistry(typeRegistry)
-                      .build())
-              .setOperationSnapshotFactory(
-                  (LongRunningRecognizeRequest request, Operation response) ->
-                      HttpJsonOperationSnapshot.create(response))
-              .build();
+                  .setFullMethodName("google.cloud.speech.v1.Speech/LongRunningRecognize")
+                  .setHttpMethod("POST")
+                  .setType(ApiMethodDescriptor.MethodType.UNARY)
+                  .setRequestFormatter(
+                          ProtoMessageRequestFormatter.<LongRunningRecognizeRequest>newBuilder()
+                                  .setPath(
+                                          "/v1/speech:longrunningrecognize",
+                                          request -> {
+                                            Map<String, String> fields = new HashMap<>();
+                                            ProtoRestSerializer<LongRunningRecognizeRequest> serializer =
+                                                    ProtoRestSerializer.create();
+                                            return fields;
+                                          })
+                                  .setQueryParamsExtractor(
+                                          request -> {
+                                            Map<String, List<String>> fields = new HashMap<>();
+                                            ProtoRestSerializer<LongRunningRecognizeRequest> serializer =
+                                                    ProtoRestSerializer.create();
+                                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
+                                            return fields;
+                                          })
+                                  .setRequestBodyExtractor(
+                                          request ->
+                                                  ProtoRestSerializer.create()
+                                                          .toBody("*", request.toBuilder().build(), true))
+                                  .build())
+                  .setResponseParser(
+                          ProtoMessageResponseParser.<Operation>newBuilder()
+                                  .setDefaultInstance(Operation.getDefaultInstance())
+                                  .setDefaultTypeRegistry(typeRegistry)
+                                  .build())
+                  .setOperationSnapshotFactory(
+                          (LongRunningRecognizeRequest request, Operation response) ->
+                                  HttpJsonOperationSnapshot.create(response))
+                  .build();
+
+  private static final ApiMethodDescriptor<ListOperationsRequest, ListOperationsResponse>
+          listOperationsMethodDescriptor =
+          ApiMethodDescriptor.<ListOperationsRequest, ListOperationsResponse>newBuilder()
+                  .setFullMethodName("google.longrunning.Operations/ListOperations")
+                  .setHttpMethod("GET")
+                  .setType(ApiMethodDescriptor.MethodType.UNARY)
+                  .setRequestFormatter(
+                          ProtoMessageRequestFormatter.<ListOperationsRequest>newBuilder()
+                                  .setPath(
+                                          "/v1/operations",
+                                          request -> {
+                                            Map<String, String> fields = new HashMap<>();
+                                            ProtoRestSerializer<ListOperationsRequest> serializer =
+                                                    ProtoRestSerializer.create();
+                                            return fields;
+                                          })
+                                  .setQueryParamsExtractor(
+                                          request -> {
+                                            Map<String, List<String>> fields = new HashMap<>();
+                                            ProtoRestSerializer<ListOperationsRequest> serializer =
+                                                    ProtoRestSerializer.create();
+                                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
+                                            return fields;
+                                          })
+                                  .setRequestBodyExtractor(request -> null)
+                                  .build())
+                  .setResponseParser(
+                          ProtoMessageResponseParser.<ListOperationsResponse>newBuilder()
+                                  .setDefaultInstance(ListOperationsResponse.getDefaultInstance())
+                                  .setDefaultTypeRegistry(typeRegistry)
+                                  .build())
+                  .build();
+
+  private static final ApiMethodDescriptor<GetOperationRequest, Operation>
+          getOperationMethodDescriptor =
+          ApiMethodDescriptor.<GetOperationRequest, Operation>newBuilder()
+                  .setFullMethodName("google.longrunning.Operations/GetOperation")
+                  .setHttpMethod(HttpMethods.GET)
+                  .setRequestFormatter(
+                          ProtoMessageRequestFormatter.<GetOperationRequest>newBuilder()
+                                  .setPath(
+                                          "/v1/operations/{name=**}",
+                                          request -> {
+                                            Map<String, String> fields = new HashMap<>();
+                                            ProtoRestSerializer<GetOperationRequest> serializer =
+                                                    ProtoRestSerializer.create();
+                                            serializer.putPathParam(fields, "name", request.getName());
+                                            return fields;
+                                          })
+                                  .setQueryParamsExtractor(request -> new HashMap<>())
+                                  .setRequestBodyExtractor(request -> null)
+                                  .build())
+                  .setResponseParser(
+                          ProtoMessageResponseParser.<Operation>newBuilder()
+                                  .setDefaultInstance(Operation.getDefaultInstance())
+                                  .build())
+                  .setOperationSnapshotFactory(
+                          (request, response) -> HttpJsonOperationSnapshot.create(response))
+                  .setPollingRequestFactory(
+                          compoundOperationId ->
+                                  GetOperationRequest.newBuilder().setName(compoundOperationId).build())
+                  .build();
+
+  private static final ApiMethodDescriptor<DeleteOperationRequest, Empty>
+          deleteOperationMethodDescriptor =
+          ApiMethodDescriptor.<DeleteOperationRequest, Empty>newBuilder()
+                  .setFullMethodName("google.longrunning.Operations/DeleteOperation")
+                  .setHttpMethod("DELETE")
+                  .setType(ApiMethodDescriptor.MethodType.UNARY)
+                  .setRequestFormatter(
+                          ProtoMessageRequestFormatter.<DeleteOperationRequest>newBuilder()
+                                  .setPath(
+                                          "/v1/{name=operations/**}",
+                                          request -> {
+                                            Map<String, String> fields = new HashMap<>();
+                                            ProtoRestSerializer<DeleteOperationRequest> serializer =
+                                                    ProtoRestSerializer.create();
+                                            serializer.putPathParam(fields, "name", request.getName());
+                                            return fields;
+                                          })
+                                  .setQueryParamsExtractor(
+                                          request -> {
+                                            Map<String, List<String>> fields = new HashMap<>();
+                                            ProtoRestSerializer<DeleteOperationRequest> serializer =
+                                                    ProtoRestSerializer.create();
+                                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
+                                            return fields;
+                                          })
+                                  .setRequestBodyExtractor(request -> null)
+                                  .build())
+                  .setResponseParser(
+                          ProtoMessageResponseParser.<Empty>newBuilder()
+                                  .setDefaultInstance(Empty.getDefaultInstance())
+                                  .setDefaultTypeRegistry(typeRegistry)
+                                  .build())
+                  .build();
+
+  private static final ApiMethodDescriptor<CancelOperationRequest, Empty>
+          cancelOperationMethodDescriptor =
+          ApiMethodDescriptor.<CancelOperationRequest, Empty>newBuilder()
+                  .setFullMethodName("google.longrunning.Operations/CancelOperation")
+                  .setHttpMethod("POST")
+                  .setType(ApiMethodDescriptor.MethodType.UNARY)
+                  .setRequestFormatter(
+                          ProtoMessageRequestFormatter.<CancelOperationRequest>newBuilder()
+                                  .setPath(
+                                          "/v1/{name=operations/**}:cancel",
+                                          request -> {
+                                            Map<String, String> fields = new HashMap<>();
+                                            ProtoRestSerializer<CancelOperationRequest> serializer =
+                                                    ProtoRestSerializer.create();
+                                            serializer.putPathParam(fields, "name", request.getName());
+                                            return fields;
+                                          })
+                                  .setQueryParamsExtractor(
+                                          request -> {
+                                            Map<String, List<String>> fields = new HashMap<>();
+                                            ProtoRestSerializer<CancelOperationRequest> serializer =
+                                                    ProtoRestSerializer.create();
+                                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
+                                            return fields;
+                                          })
+                                  .setRequestBodyExtractor(
+                                          request ->
+                                                  ProtoRestSerializer.create()
+                                                          .toBody("*", request.toBuilder().clearName().build(), true))
+                                  .build())
+                  .setResponseParser(
+                          ProtoMessageResponseParser.<Empty>newBuilder()
+                                  .setDefaultInstance(Empty.getDefaultInstance())
+                                  .setDefaultTypeRegistry(typeRegistry)
+                                  .build())
+                  .build();
 
   private final UnaryCallable<RecognizeRequest, RecognizeResponse> recognizeCallable;
   private final UnaryCallable<LongRunningRecognizeRequest, Operation> longRunningRecognizeCallable;
   private final OperationCallable<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-      longRunningRecognizeOperationCallable;
+          longRunningRecognizeOperationCallable;
+  private final UnaryCallable<ListOperationsRequest, ListOperationsResponse> listOperationsCallable;
+  private final UnaryCallable<ListOperationsRequest, ListOperationsPagedResponse>
+          listOperationsPagedCallable;
+  private final UnaryCallable<GetOperationRequest, Operation> getOperationCallable;
+  private final UnaryCallable<DeleteOperationRequest, Empty> deleteOperationCallable;
+  private final UnaryCallable<CancelOperationRequest, Empty> cancelOperationCallable;
 
   private final BackgroundResource backgroundResources;
-  private final HttpJsonOperationsStub httpJsonOperationsStub;
+  //  private final HttpJsonOperationsStub httpJsonOperationsStub;
   private final HttpJsonStubCallableFactory callableFactory;
 
   public static final HttpJsonSpeechStub create(SpeechStubSettings settings) throws IOException {
@@ -158,9 +312,9 @@ public class HttpJsonSpeechStub extends SpeechStub {
   }
 
   public static final HttpJsonSpeechStub create(
-      ClientContext clientContext, HttpJsonStubCallableFactory callableFactory) throws IOException {
+          ClientContext clientContext, HttpJsonStubCallableFactory callableFactory) throws IOException {
     return new HttpJsonSpeechStub(
-        SpeechStubSettings.newHttpJsonBuilder().build(), clientContext, callableFactory);
+            SpeechStubSettings.newHttpJsonBuilder().build(), clientContext, callableFactory);
   }
 
   /**
@@ -169,7 +323,7 @@ public class HttpJsonSpeechStub extends SpeechStub {
    * preferred.
    */
   protected HttpJsonSpeechStub(SpeechStubSettings settings, ClientContext clientContext)
-      throws IOException {
+          throws IOException {
     this(settings, clientContext, new HttpJsonSpeechCallableFactory());
   }
 
@@ -179,43 +333,83 @@ public class HttpJsonSpeechStub extends SpeechStub {
    * preferred.
    */
   protected HttpJsonSpeechStub(
-      SpeechStubSettings settings,
-      ClientContext clientContext,
-      HttpJsonStubCallableFactory callableFactory)
-      throws IOException {
+          SpeechStubSettings settings,
+          ClientContext clientContext,
+          HttpJsonStubCallableFactory callableFactory)
+          throws IOException {
     this.callableFactory = callableFactory;
-    this.httpJsonOperationsStub =
+    HttpJsonOperationsStub httpJsonOperationsStub =
         HttpJsonOperationsStub.create(clientContext, callableFactory, typeRegistry);
 
+    HttpJsonCallSettings<ListOperationsRequest, ListOperationsResponse>
+            listOperationsTransportSettings =
+            HttpJsonCallSettings.<ListOperationsRequest, ListOperationsResponse>newBuilder()
+                    .setMethodDescriptor(listOperationsMethodDescriptor)
+                    .setTypeRegistry(typeRegistry)
+                    .build();
+    HttpJsonCallSettings<GetOperationRequest, Operation> getOperationTransportSettings =
+            HttpJsonCallSettings.<GetOperationRequest, Operation>newBuilder()
+                    .setMethodDescriptor(getOperationMethodDescriptor)
+                    .setTypeRegistry(typeRegistry)
+                    .build();
+    HttpJsonCallSettings<DeleteOperationRequest, Empty> deleteOperationTransportSettings =
+            HttpJsonCallSettings.<DeleteOperationRequest, Empty>newBuilder()
+                    .setMethodDescriptor(deleteOperationMethodDescriptor)
+                    .setTypeRegistry(typeRegistry)
+                    .build();
+    HttpJsonCallSettings<CancelOperationRequest, Empty> cancelOperationTransportSettings =
+            HttpJsonCallSettings.<CancelOperationRequest, Empty>newBuilder()
+                    .setMethodDescriptor(cancelOperationMethodDescriptor)
+                    .setTypeRegistry(typeRegistry)
+                    .build();
+
+    this.listOperationsCallable =
+            callableFactory.createUnaryCallable(
+                    listOperationsTransportSettings, OperationsStubSettings.newBuilder().build().listOperationsSettings(), clientContext);
+    this.listOperationsPagedCallable =
+            callableFactory.createPagedCallable(
+                    listOperationsTransportSettings, OperationsStubSettings.newBuilder().build().listOperationsSettings(), clientContext);
+    this.getOperationCallable =
+            callableFactory.createUnaryCallable(
+                    getOperationTransportSettings, OperationsStubSettings.newBuilder().build().getOperationSettings(), clientContext);
+    this.deleteOperationCallable =
+            callableFactory.createUnaryCallable(
+                    deleteOperationTransportSettings, OperationsStubSettings.newBuilder().build().deleteOperationSettings(), clientContext);
+    this.cancelOperationCallable =
+            callableFactory.createUnaryCallable(
+                    cancelOperationTransportSettings, OperationsStubSettings.newBuilder().build().cancelOperationSettings(), clientContext);
+
+    LongRunningClient longRunningClient = new HttpJsonLongRunningClient(this.getOperationCallable, getOperationMethodDescriptor.getOperationSnapshotFactory(), getOperationMethodDescriptor.getPollingRequestFactory());
+
     HttpJsonCallSettings<RecognizeRequest, RecognizeResponse> recognizeTransportSettings =
-        HttpJsonCallSettings.<RecognizeRequest, RecognizeResponse>newBuilder()
-            .setMethodDescriptor(recognizeMethodDescriptor)
-            .setTypeRegistry(typeRegistry)
-            .build();
+            HttpJsonCallSettings.<RecognizeRequest, RecognizeResponse>newBuilder()
+                    .setMethodDescriptor(recognizeMethodDescriptor)
+                    .setTypeRegistry(typeRegistry)
+                    .build();
     HttpJsonCallSettings<LongRunningRecognizeRequest, Operation>
-        longRunningRecognizeTransportSettings =
+            longRunningRecognizeTransportSettings =
             HttpJsonCallSettings.<LongRunningRecognizeRequest, Operation>newBuilder()
-                .setMethodDescriptor(longRunningRecognizeMethodDescriptor)
-                .setTypeRegistry(typeRegistry)
-                .build();
+                    .setMethodDescriptor(longRunningRecognizeMethodDescriptor)
+                    .setTypeRegistry(typeRegistry)
+                    .build();
 
     this.recognizeCallable =
-        callableFactory.createUnaryCallable(
-            recognizeTransportSettings, settings.recognizeSettings(), clientContext);
+            callableFactory.createUnaryCallable(
+                    recognizeTransportSettings, settings.recognizeSettings(), clientContext);
     this.longRunningRecognizeCallable =
-        callableFactory.createUnaryCallable(
-            longRunningRecognizeTransportSettings,
-            settings.longRunningRecognizeSettings(),
-            clientContext);
+            callableFactory.createUnaryCallable(
+                    longRunningRecognizeTransportSettings,
+                    settings.longRunningRecognizeSettings(),
+                    clientContext);
     this.longRunningRecognizeOperationCallable =
-        callableFactory.createOperationCallable(
-            longRunningRecognizeTransportSettings,
-            settings.longRunningRecognizeOperationSettings(),
-            clientContext,
-            httpJsonOperationsStub);
+            callableFactory.createOperationCallable(
+                    longRunningRecognizeTransportSettings,
+                    settings.longRunningRecognizeOperationSettings(),
+                    clientContext,
+                    longRunningClient);
 
     this.backgroundResources =
-        new BackgroundResourceAggregation(clientContext.getBackgroundResources());
+            new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
 
   @InternalApi
@@ -223,12 +417,16 @@ public class HttpJsonSpeechStub extends SpeechStub {
     List<ApiMethodDescriptor> methodDescriptors = new ArrayList<>();
     methodDescriptors.add(recognizeMethodDescriptor);
     methodDescriptors.add(longRunningRecognizeMethodDescriptor);
+    methodDescriptors.add(listOperationsMethodDescriptor);
+    methodDescriptors.add(getOperationMethodDescriptor);
+    methodDescriptors.add(deleteOperationMethodDescriptor);
+    methodDescriptors.add(cancelOperationMethodDescriptor);
     return methodDescriptors;
   }
 
-  public HttpJsonOperationsStub getHttpJsonOperationsStub() {
-    return httpJsonOperationsStub;
-  }
+//  public HttpJsonOperationsStub getHttpJsonOperationsStub() {
+//    return httpJsonOperationsStub;
+//  }
 
   @Override
   public UnaryCallable<RecognizeRequest, RecognizeResponse> recognizeCallable() {
@@ -243,15 +441,47 @@ public class HttpJsonSpeechStub extends SpeechStub {
   @Override
   public OperationCallable<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-      longRunningRecognizeOperationCallable() {
+  longRunningRecognizeOperationCallable() {
     return longRunningRecognizeOperationCallable;
   }
 
   @Override
+  public UnaryCallable<ListOperationsRequest, ListOperationsResponse> listOperationsCallable() {
+    return listOperationsCallable;
+  }
+
+  @Override
+  public UnaryCallable<ListOperationsRequest, ListOperationsPagedResponse>
+  listOperationsPagedCallable() {
+    return listOperationsPagedCallable;
+  }
+
+  @Override
+  public UnaryCallable<GetOperationRequest, Operation> getOperationCallable() {
+    return getOperationCallable;
+  }
+
+  @Override
+  public UnaryCallable<DeleteOperationRequest, Empty> deleteOperationCallable() {
+    return deleteOperationCallable;
+  }
+
+  @Override
+  public UnaryCallable<CancelOperationRequest, Empty> cancelOperationCallable() {
+    return cancelOperationCallable;
+  }
+
+  @Override
   public BidiStreamingCallable<StreamingRecognizeRequest, StreamingRecognizeResponse>
-      streamingRecognizeCallable() {
+  streamingRecognizeCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: streamingRecognizeCallable(). REST transport is not implemented for this method yet.");
+            "Not implemented: streamingRecognizeCallable(). REST transport is not implemented for this method yet.");
+  }
+
+  @Override
+  public UnaryCallable<WaitOperationRequest, Operation> waitOperationCallable() {
+    throw new UnsupportedOperationException(
+            "Not implemented: waitOperationCallable(). REST transport is not implemented for this method yet.");
   }
 
   @Override

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/SpeechStub.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/SpeechStub.java
@@ -63,9 +63,9 @@ public abstract class SpeechStub implements BackgroundResource {
 
   public OperationCallable<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-  longRunningRecognizeOperationCallable() {
+      longRunningRecognizeOperationCallable() {
     throw new UnsupportedOperationException(
-            "Not implemented: longRunningRecognizeOperationCallable()");
+        "Not implemented: longRunningRecognizeOperationCallable()");
   }
 
   public UnaryCallable<LongRunningRecognizeRequest, Operation> longRunningRecognizeCallable() {
@@ -73,12 +73,12 @@ public abstract class SpeechStub implements BackgroundResource {
   }
 
   public BidiStreamingCallable<StreamingRecognizeRequest, StreamingRecognizeResponse>
-  streamingRecognizeCallable() {
+      streamingRecognizeCallable() {
     throw new UnsupportedOperationException("Not implemented: streamingRecognizeCallable()");
   }
 
   public UnaryCallable<ListOperationsRequest, ListOperationsPagedResponse>
-  listOperationsPagedCallable() {
+      listOperationsPagedCallable() {
     throw new UnsupportedOperationException("Not implemented: listOperationsPagedCallable()");
   }
 

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/SpeechStub.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/SpeechStub.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.speech.v1.stub;
 
+import static com.google.cloud.speech.v1.SpeechClient.ListOperationsPagedResponse;
+
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.OperationCallable;
@@ -27,8 +29,15 @@ import com.google.cloud.speech.v1.RecognizeRequest;
 import com.google.cloud.speech.v1.RecognizeResponse;
 import com.google.cloud.speech.v1.StreamingRecognizeRequest;
 import com.google.cloud.speech.v1.StreamingRecognizeResponse;
+import com.google.longrunning.CancelOperationRequest;
+import com.google.longrunning.DeleteOperationRequest;
+import com.google.longrunning.GetOperationRequest;
+import com.google.longrunning.ListOperationsRequest;
+import com.google.longrunning.ListOperationsResponse;
 import com.google.longrunning.Operation;
+import com.google.longrunning.WaitOperationRequest;
 import com.google.longrunning.stub.OperationsStub;
+import com.google.protobuf.Empty;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
@@ -54,9 +63,9 @@ public abstract class SpeechStub implements BackgroundResource {
 
   public OperationCallable<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-      longRunningRecognizeOperationCallable() {
+  longRunningRecognizeOperationCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: longRunningRecognizeOperationCallable()");
+            "Not implemented: longRunningRecognizeOperationCallable()");
   }
 
   public UnaryCallable<LongRunningRecognizeRequest, Operation> longRunningRecognizeCallable() {
@@ -64,8 +73,33 @@ public abstract class SpeechStub implements BackgroundResource {
   }
 
   public BidiStreamingCallable<StreamingRecognizeRequest, StreamingRecognizeResponse>
-      streamingRecognizeCallable() {
+  streamingRecognizeCallable() {
     throw new UnsupportedOperationException("Not implemented: streamingRecognizeCallable()");
+  }
+
+  public UnaryCallable<ListOperationsRequest, ListOperationsPagedResponse>
+  listOperationsPagedCallable() {
+    throw new UnsupportedOperationException("Not implemented: listOperationsPagedCallable()");
+  }
+
+  public UnaryCallable<ListOperationsRequest, ListOperationsResponse> listOperationsCallable() {
+    throw new UnsupportedOperationException("Not implemented: listOperationsCallable()");
+  }
+
+  public UnaryCallable<GetOperationRequest, Operation> getOperationCallable() {
+    throw new UnsupportedOperationException("Not implemented: getOperationCallable()");
+  }
+
+  public UnaryCallable<DeleteOperationRequest, Empty> deleteOperationCallable() {
+    throw new UnsupportedOperationException("Not implemented: deleteOperationCallable()");
+  }
+
+  public UnaryCallable<CancelOperationRequest, Empty> cancelOperationCallable() {
+    throw new UnsupportedOperationException("Not implemented: cancelOperationCallable()");
+  }
+
+  public UnaryCallable<WaitOperationRequest, Operation> waitOperationCallable() {
+    throw new UnsupportedOperationException("Not implemented: waitOperationCallable()");
   }
 
   @Override

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/SpeechStubSettings.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/SpeechStubSettings.java
@@ -112,26 +112,26 @@ import org.threeten.bp.Duration;
 public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
   /** The default scopes of the service. */
   private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
-          ImmutableList.<String>builder().add("https://www.googleapis.com/auth/cloud-platform").build();
+      ImmutableList.<String>builder().add("https://www.googleapis.com/auth/cloud-platform").build();
 
   private final UnaryCallSettings<RecognizeRequest, RecognizeResponse> recognizeSettings;
   private final UnaryCallSettings<LongRunningRecognizeRequest, Operation>
-          longRunningRecognizeSettings;
+      longRunningRecognizeSettings;
   private final OperationCallSettings<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-          longRunningRecognizeOperationSettings;
+      longRunningRecognizeOperationSettings;
   private final StreamingCallSettings<StreamingRecognizeRequest, StreamingRecognizeResponse>
-          streamingRecognizeSettings;
+      streamingRecognizeSettings;
   private final PagedCallSettings<
           ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>
-          listOperationsSettings;
+      listOperationsSettings;
   private final UnaryCallSettings<GetOperationRequest, Operation> getOperationSettings;
   private final UnaryCallSettings<DeleteOperationRequest, Empty> deleteOperationSettings;
   private final UnaryCallSettings<CancelOperationRequest, Empty> cancelOperationSettings;
   private final UnaryCallSettings<WaitOperationRequest, Operation> waitOperationSettings;
 
   private static final PagedListDescriptor<ListOperationsRequest, ListOperationsResponse, Operation>
-          LIST_OPERATIONS_PAGE_STR_DESC =
+      LIST_OPERATIONS_PAGE_STR_DESC =
           new PagedListDescriptor<ListOperationsRequest, ListOperationsResponse, Operation>() {
             @Override
             public String emptyToken() {
@@ -145,7 +145,7 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
 
             @Override
             public ListOperationsRequest injectPageSize(
-                    ListOperationsRequest payload, int pageSize) {
+                ListOperationsRequest payload, int pageSize) {
               return ListOperationsRequest.newBuilder(payload).setPageSize(pageSize).build();
             }
 
@@ -162,24 +162,24 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
             @Override
             public Iterable<Operation> extractResources(ListOperationsResponse payload) {
               return payload.getOperationsList() == null
-                      ? ImmutableList.<Operation>of()
-                      : payload.getOperationsList();
+                  ? ImmutableList.<Operation>of()
+                  : payload.getOperationsList();
             }
           };
 
   private static final PagedListResponseFactory<
           ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>
-          LIST_OPERATIONS_PAGE_STR_FACT =
+      LIST_OPERATIONS_PAGE_STR_FACT =
           new PagedListResponseFactory<
-                  ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>() {
+              ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>() {
             @Override
             public ApiFuture<ListOperationsPagedResponse> getFuturePagedResponse(
-                    UnaryCallable<ListOperationsRequest, ListOperationsResponse> callable,
-                    ListOperationsRequest request,
-                    ApiCallContext context,
-                    ApiFuture<ListOperationsResponse> futureResponse) {
+                UnaryCallable<ListOperationsRequest, ListOperationsResponse> callable,
+                ListOperationsRequest request,
+                ApiCallContext context,
+                ApiFuture<ListOperationsResponse> futureResponse) {
               PageContext<ListOperationsRequest, ListOperationsResponse, Operation> pageContext =
-                      PageContext.create(callable, LIST_OPERATIONS_PAGE_STR_DESC, request, context);
+                  PageContext.create(callable, LIST_OPERATIONS_PAGE_STR_DESC, request, context);
               return ListOperationsPagedResponse.createAsync(pageContext, futureResponse);
             }
           };
@@ -197,20 +197,20 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
   /** Returns the object with the settings used for calls to longRunningRecognize. */
   public OperationCallSettings<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-  longRunningRecognizeOperationSettings() {
+      longRunningRecognizeOperationSettings() {
     return longRunningRecognizeOperationSettings;
   }
 
   /** Returns the object with the settings used for calls to streamingRecognize. */
   public StreamingCallSettings<StreamingRecognizeRequest, StreamingRecognizeResponse>
-  streamingRecognizeSettings() {
+      streamingRecognizeSettings() {
     return streamingRecognizeSettings;
   }
 
   /** Returns the object with the settings used for calls to listOperations. */
   public PagedCallSettings<
           ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>
-  listOperationsSettings() {
+      listOperationsSettings() {
     return listOperationsSettings;
   }
 
@@ -236,18 +236,18 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
 
   public SpeechStub createStub() throws IOException {
     if (getTransportChannelProvider()
-            .getTransportName()
-            .equals(GrpcTransportChannel.getGrpcTransportName())) {
+        .getTransportName()
+        .equals(GrpcTransportChannel.getGrpcTransportName())) {
       return GrpcSpeechStub.create(this);
     }
     if (getTransportChannelProvider()
-            .getTransportName()
-            .equals(HttpJsonTransportChannel.getHttpJsonTransportName())) {
+        .getTransportName()
+        .equals(HttpJsonTransportChannel.getHttpJsonTransportName())) {
       return HttpJsonSpeechStub.create(this);
     }
     throw new UnsupportedOperationException(
-            String.format(
-                    "Transport not supported: %s", getTransportChannelProvider().getTransportName()));
+        String.format(
+            "Transport not supported: %s", getTransportChannelProvider().getTransportName()));
   }
 
   /** Returns a builder for the default ExecutorProvider for this service. */
@@ -273,20 +273,20 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
     return GoogleCredentialsProvider.newBuilder()
-            .setScopesToApply(DEFAULT_SERVICE_SCOPES)
-            .setUseJwtAccessWithScope(true);
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default gRPC ChannelProvider for this service. */
   public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder() {
     return InstantiatingGrpcChannelProvider.newBuilder()
-            .setMaxInboundMessageSize(Integer.MAX_VALUE);
+        .setMaxInboundMessageSize(Integer.MAX_VALUE);
   }
 
   /** Returns a builder for the default REST ChannelProvider for this service. */
   @BetaApi
   public static InstantiatingHttpJsonChannelProvider.Builder
-  defaultHttpJsonTransportProviderBuilder() {
+      defaultHttpJsonTransportProviderBuilder() {
     return InstantiatingHttpJsonChannelProvider.newBuilder();
   }
 
@@ -297,18 +297,18 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultGrpcApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
-            .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(SpeechStubSettings.class))
-            .setTransportToken(
-                    GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(SpeechStubSettings.class))
+        .setTransportToken(
+            GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
   }
 
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultHttpJsonApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
-            .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(SpeechStubSettings.class))
-            .setTransportToken(
-                    GaxHttpJsonProperties.getHttpJsonTokenName(),
-                    GaxHttpJsonProperties.getHttpJsonVersion());
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(SpeechStubSettings.class))
+        .setTransportToken(
+            GaxHttpJsonProperties.getHttpJsonTokenName(),
+            GaxHttpJsonProperties.getHttpJsonVersion());
   }
 
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
@@ -341,7 +341,7 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
     recognizeSettings = settingsBuilder.recognizeSettings().build();
     longRunningRecognizeSettings = settingsBuilder.longRunningRecognizeSettings().build();
     longRunningRecognizeOperationSettings =
-            settingsBuilder.longRunningRecognizeOperationSettings().build();
+        settingsBuilder.longRunningRecognizeOperationSettings().build();
     streamingRecognizeSettings = settingsBuilder.streamingRecognizeSettings().build();
     listOperationsSettings = settingsBuilder.listOperationsSettings().build();
     getOperationSettings = settingsBuilder.getOperationSettings().build();
@@ -355,33 +355,33 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
     private final UnaryCallSettings.Builder<RecognizeRequest, RecognizeResponse> recognizeSettings;
     private final UnaryCallSettings.Builder<LongRunningRecognizeRequest, Operation>
-            longRunningRecognizeSettings;
+        longRunningRecognizeSettings;
     private final OperationCallSettings.Builder<
             LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-            longRunningRecognizeOperationSettings;
+        longRunningRecognizeOperationSettings;
     private final StreamingCallSettings.Builder<
             StreamingRecognizeRequest, StreamingRecognizeResponse>
-            streamingRecognizeSettings;
+        streamingRecognizeSettings;
     private final PagedCallSettings.Builder<
             ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>
-            listOperationsSettings;
+        listOperationsSettings;
     private final UnaryCallSettings.Builder<GetOperationRequest, Operation> getOperationSettings;
     private final UnaryCallSettings.Builder<DeleteOperationRequest, Empty> deleteOperationSettings;
     private final UnaryCallSettings.Builder<CancelOperationRequest, Empty> cancelOperationSettings;
     private final UnaryCallSettings.Builder<WaitOperationRequest, Operation> waitOperationSettings;
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
-            RETRYABLE_CODE_DEFINITIONS;
+        RETRYABLE_CODE_DEFINITIONS;
 
     static {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions =
-              ImmutableMap.builder();
+          ImmutableMap.builder();
       definitions.put(
-              "retry_policy_0_codes",
-              ImmutableSet.copyOf(
-                      Lists.<StatusCode.Code>newArrayList(
-                              StatusCode.Code.UNAVAILABLE, StatusCode.Code.DEADLINE_EXCEEDED)));
+          "retry_policy_0_codes",
+          ImmutableSet.copyOf(
+              Lists.<StatusCode.Code>newArrayList(
+                  StatusCode.Code.UNAVAILABLE, StatusCode.Code.DEADLINE_EXCEEDED)));
       definitions.put(
-              "no_retry_1_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+          "no_retry_1_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
       definitions.put("no_retry_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
       RETRYABLE_CODE_DEFINITIONS = definitions.build();
     }
@@ -392,23 +392,23 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
       ImmutableMap.Builder<String, RetrySettings> definitions = ImmutableMap.builder();
       RetrySettings settings = null;
       settings =
-              RetrySettings.newBuilder()
-                      .setInitialRetryDelay(Duration.ofMillis(100L))
-                      .setRetryDelayMultiplier(1.3)
-                      .setMaxRetryDelay(Duration.ofMillis(60000L))
-                      .setInitialRpcTimeout(Duration.ofMillis(5000000L))
-                      .setRpcTimeoutMultiplier(1.0)
-                      .setMaxRpcTimeout(Duration.ofMillis(5000000L))
-                      .setTotalTimeout(Duration.ofMillis(5000000L))
-                      .build();
+          RetrySettings.newBuilder()
+              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setRetryDelayMultiplier(1.3)
+              .setMaxRetryDelay(Duration.ofMillis(60000L))
+              .setInitialRpcTimeout(Duration.ofMillis(5000000L))
+              .setRpcTimeoutMultiplier(1.0)
+              .setMaxRpcTimeout(Duration.ofMillis(5000000L))
+              .setTotalTimeout(Duration.ofMillis(5000000L))
+              .build();
       definitions.put("retry_policy_0_params", settings);
       settings =
-              RetrySettings.newBuilder()
-                      .setInitialRpcTimeout(Duration.ofMillis(5000000L))
-                      .setRpcTimeoutMultiplier(1.0)
-                      .setMaxRpcTimeout(Duration.ofMillis(5000000L))
-                      .setTotalTimeout(Duration.ofMillis(5000000L))
-                      .build();
+          RetrySettings.newBuilder()
+              .setInitialRpcTimeout(Duration.ofMillis(5000000L))
+              .setRpcTimeoutMultiplier(1.0)
+              .setMaxRpcTimeout(Duration.ofMillis(5000000L))
+              .setTotalTimeout(Duration.ofMillis(5000000L))
+              .build();
       definitions.put("no_retry_1_params", settings);
       settings = RetrySettings.newBuilder().setRpcTimeoutMultiplier(1.0).build();
       definitions.put("no_retry_params", settings);
@@ -433,14 +433,14 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
       waitOperationSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders =
-              ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-                      recognizeSettings,
-                      longRunningRecognizeSettings,
-                      listOperationsSettings,
-                      getOperationSettings,
-                      deleteOperationSettings,
-                      cancelOperationSettings,
-                      waitOperationSettings);
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+              recognizeSettings,
+              longRunningRecognizeSettings,
+              listOperationsSettings,
+              getOperationSettings,
+              deleteOperationSettings,
+              cancelOperationSettings,
+              waitOperationSettings);
       initDefaults(this);
     }
 
@@ -450,7 +450,7 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
       recognizeSettings = settings.recognizeSettings.toBuilder();
       longRunningRecognizeSettings = settings.longRunningRecognizeSettings.toBuilder();
       longRunningRecognizeOperationSettings =
-              settings.longRunningRecognizeOperationSettings.toBuilder();
+          settings.longRunningRecognizeOperationSettings.toBuilder();
       streamingRecognizeSettings = settings.streamingRecognizeSettings.toBuilder();
       listOperationsSettings = settings.listOperationsSettings.toBuilder();
       getOperationSettings = settings.getOperationSettings.toBuilder();
@@ -459,14 +459,14 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
       waitOperationSettings = settings.waitOperationSettings.toBuilder();
 
       unaryMethodSettingsBuilders =
-              ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-                      recognizeSettings,
-                      longRunningRecognizeSettings,
-                      listOperationsSettings,
-                      getOperationSettings,
-                      deleteOperationSettings,
-                      cancelOperationSettings,
-                      waitOperationSettings);
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+              recognizeSettings,
+              longRunningRecognizeSettings,
+              listOperationsSettings,
+              getOperationSettings,
+              deleteOperationSettings,
+              cancelOperationSettings,
+              waitOperationSettings);
     }
 
     private static Builder createDefault() {
@@ -497,65 +497,65 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
 
     private static Builder initDefaults(Builder builder) {
       builder
-              .recognizeSettings()
-              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_0_codes"))
-              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_0_params"));
+          .recognizeSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_0_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_0_params"));
 
       builder
-              .longRunningRecognizeSettings()
-              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
-              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"));
+          .longRunningRecognizeSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"));
 
       builder
-              .listOperationsSettings()
-              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
-              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+          .listOperationsSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
 
       builder
-              .getOperationSettings()
-              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
-              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+          .getOperationSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
 
       builder
-              .deleteOperationSettings()
-              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
-              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+          .deleteOperationSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
 
       builder
-              .cancelOperationSettings()
-              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
-              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+          .cancelOperationSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
 
       builder
-              .waitOperationSettings()
-              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
-              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+          .waitOperationSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
 
       builder
-              .longRunningRecognizeOperationSettings()
-              .setInitialCallSettings(
-                      UnaryCallSettings
-                              .<LongRunningRecognizeRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
-                              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
-                              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"))
-                              .build())
-              .setResponseTransformer(
-                      ProtoOperationTransformers.ResponseTransformer.create(
-                              LongRunningRecognizeResponse.class))
-              .setMetadataTransformer(
-                      ProtoOperationTransformers.MetadataTransformer.create(
-                              LongRunningRecognizeMetadata.class))
-              .setPollingAlgorithm(
-                      OperationTimedPollAlgorithm.create(
-                              RetrySettings.newBuilder()
-                                      .setInitialRetryDelay(Duration.ofMillis(5000L))
-                                      .setRetryDelayMultiplier(1.5)
-                                      .setMaxRetryDelay(Duration.ofMillis(45000L))
-                                      .setInitialRpcTimeout(Duration.ZERO)
-                                      .setRpcTimeoutMultiplier(1.0)
-                                      .setMaxRpcTimeout(Duration.ZERO)
-                                      .setTotalTimeout(Duration.ofMillis(300000L))
-                                      .build()));
+          .longRunningRecognizeOperationSettings()
+          .setInitialCallSettings(
+              UnaryCallSettings
+                  .<LongRunningRecognizeRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
+                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"))
+                  .build())
+          .setResponseTransformer(
+              ProtoOperationTransformers.ResponseTransformer.create(
+                  LongRunningRecognizeResponse.class))
+          .setMetadataTransformer(
+              ProtoOperationTransformers.MetadataTransformer.create(
+                  LongRunningRecognizeMetadata.class))
+          .setPollingAlgorithm(
+              OperationTimedPollAlgorithm.create(
+                  RetrySettings.newBuilder()
+                      .setInitialRetryDelay(Duration.ofMillis(5000L))
+                      .setRetryDelayMultiplier(1.5)
+                      .setMaxRetryDelay(Duration.ofMillis(45000L))
+                      .setInitialRpcTimeout(Duration.ZERO)
+                      .setRpcTimeoutMultiplier(1.0)
+                      .setMaxRpcTimeout(Duration.ZERO)
+                      .setTotalTimeout(Duration.ofMillis(300000L))
+                      .build()));
 
       return builder;
     }
@@ -566,7 +566,7 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
      * <p>Note: This method does not support applying settings to streaming methods.
      */
     public Builder applyToAllUnaryMethods(
-            ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
+        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
       super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, settingsUpdater);
       return this;
     }
@@ -582,29 +582,29 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
 
     /** Returns the builder for the settings used for calls to longRunningRecognize. */
     public UnaryCallSettings.Builder<LongRunningRecognizeRequest, Operation>
-    longRunningRecognizeSettings() {
+        longRunningRecognizeSettings() {
       return longRunningRecognizeSettings;
     }
 
     /** Returns the builder for the settings used for calls to longRunningRecognize. */
     @BetaApi(
-            "The surface for use by generated code is not stable yet and may change in the future.")
+        "The surface for use by generated code is not stable yet and may change in the future.")
     public OperationCallSettings.Builder<
             LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-    longRunningRecognizeOperationSettings() {
+        longRunningRecognizeOperationSettings() {
       return longRunningRecognizeOperationSettings;
     }
 
     /** Returns the builder for the settings used for calls to streamingRecognize. */
     public StreamingCallSettings.Builder<StreamingRecognizeRequest, StreamingRecognizeResponse>
-    streamingRecognizeSettings() {
+        streamingRecognizeSettings() {
       return streamingRecognizeSettings;
     }
 
     /** Returns the builder for the settings used for calls to listOperations. */
     public PagedCallSettings.Builder<
             ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>
-    listOperationsSettings() {
+        listOperationsSettings() {
       return listOperationsSettings;
     }
 

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/SpeechStubSettings.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/SpeechStubSettings.java
@@ -16,7 +16,10 @@
 
 package com.google.cloud.speech.v1.stub;
 
+import static com.google.cloud.speech.v1.SpeechClient.ListOperationsPagedResponse;
+
 import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
@@ -31,14 +34,20 @@ import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.PageContext;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.PagedListDescriptor;
+import com.google.api.gax.rpc.PagedListResponseFactory;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.StreamingCallSettings;
 import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.speech.v1.LongRunningRecognizeMetadata;
 import com.google.cloud.speech.v1.LongRunningRecognizeRequest;
 import com.google.cloud.speech.v1.LongRunningRecognizeResponse;
@@ -50,7 +59,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.longrunning.CancelOperationRequest;
+import com.google.longrunning.DeleteOperationRequest;
+import com.google.longrunning.GetOperationRequest;
+import com.google.longrunning.ListOperationsRequest;
+import com.google.longrunning.ListOperationsResponse;
 import com.google.longrunning.Operation;
+import com.google.longrunning.WaitOperationRequest;
+import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
@@ -96,16 +112,77 @@ import org.threeten.bp.Duration;
 public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
   /** The default scopes of the service. */
   private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
-      ImmutableList.<String>builder().add("https://www.googleapis.com/auth/cloud-platform").build();
+          ImmutableList.<String>builder().add("https://www.googleapis.com/auth/cloud-platform").build();
 
   private final UnaryCallSettings<RecognizeRequest, RecognizeResponse> recognizeSettings;
   private final UnaryCallSettings<LongRunningRecognizeRequest, Operation>
-      longRunningRecognizeSettings;
+          longRunningRecognizeSettings;
   private final OperationCallSettings<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-      longRunningRecognizeOperationSettings;
+          longRunningRecognizeOperationSettings;
   private final StreamingCallSettings<StreamingRecognizeRequest, StreamingRecognizeResponse>
-      streamingRecognizeSettings;
+          streamingRecognizeSettings;
+  private final PagedCallSettings<
+          ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>
+          listOperationsSettings;
+  private final UnaryCallSettings<GetOperationRequest, Operation> getOperationSettings;
+  private final UnaryCallSettings<DeleteOperationRequest, Empty> deleteOperationSettings;
+  private final UnaryCallSettings<CancelOperationRequest, Empty> cancelOperationSettings;
+  private final UnaryCallSettings<WaitOperationRequest, Operation> waitOperationSettings;
+
+  private static final PagedListDescriptor<ListOperationsRequest, ListOperationsResponse, Operation>
+          LIST_OPERATIONS_PAGE_STR_DESC =
+          new PagedListDescriptor<ListOperationsRequest, ListOperationsResponse, Operation>() {
+            @Override
+            public String emptyToken() {
+              return "";
+            }
+
+            @Override
+            public ListOperationsRequest injectToken(ListOperationsRequest payload, String token) {
+              return ListOperationsRequest.newBuilder(payload).setPageToken(token).build();
+            }
+
+            @Override
+            public ListOperationsRequest injectPageSize(
+                    ListOperationsRequest payload, int pageSize) {
+              return ListOperationsRequest.newBuilder(payload).setPageSize(pageSize).build();
+            }
+
+            @Override
+            public Integer extractPageSize(ListOperationsRequest payload) {
+              return payload.getPageSize();
+            }
+
+            @Override
+            public String extractNextToken(ListOperationsResponse payload) {
+              return payload.getNextPageToken();
+            }
+
+            @Override
+            public Iterable<Operation> extractResources(ListOperationsResponse payload) {
+              return payload.getOperationsList() == null
+                      ? ImmutableList.<Operation>of()
+                      : payload.getOperationsList();
+            }
+          };
+
+  private static final PagedListResponseFactory<
+          ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>
+          LIST_OPERATIONS_PAGE_STR_FACT =
+          new PagedListResponseFactory<
+                  ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>() {
+            @Override
+            public ApiFuture<ListOperationsPagedResponse> getFuturePagedResponse(
+                    UnaryCallable<ListOperationsRequest, ListOperationsResponse> callable,
+                    ListOperationsRequest request,
+                    ApiCallContext context,
+                    ApiFuture<ListOperationsResponse> futureResponse) {
+              PageContext<ListOperationsRequest, ListOperationsResponse, Operation> pageContext =
+                      PageContext.create(callable, LIST_OPERATIONS_PAGE_STR_DESC, request, context);
+              return ListOperationsPagedResponse.createAsync(pageContext, futureResponse);
+            }
+          };
 
   /** Returns the object with the settings used for calls to recognize. */
   public UnaryCallSettings<RecognizeRequest, RecognizeResponse> recognizeSettings() {
@@ -120,30 +197,57 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
   /** Returns the object with the settings used for calls to longRunningRecognize. */
   public OperationCallSettings<
           LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-      longRunningRecognizeOperationSettings() {
+  longRunningRecognizeOperationSettings() {
     return longRunningRecognizeOperationSettings;
   }
 
   /** Returns the object with the settings used for calls to streamingRecognize. */
   public StreamingCallSettings<StreamingRecognizeRequest, StreamingRecognizeResponse>
-      streamingRecognizeSettings() {
+  streamingRecognizeSettings() {
     return streamingRecognizeSettings;
+  }
+
+  /** Returns the object with the settings used for calls to listOperations. */
+  public PagedCallSettings<
+          ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>
+  listOperationsSettings() {
+    return listOperationsSettings;
+  }
+
+  /** Returns the object with the settings used for calls to get. */
+  public UnaryCallSettings<GetOperationRequest, Operation> getOperationSettings() {
+    return getOperationSettings;
+  }
+
+  /** Returns the object with the settings used for calls to delete. */
+  public UnaryCallSettings<DeleteOperationRequest, Empty> deleteOperationSettings() {
+    return deleteOperationSettings;
+  }
+
+  /** Returns the object with the settings used for calls to cancel. */
+  public UnaryCallSettings<CancelOperationRequest, Empty> cancelOperationSettings() {
+    return cancelOperationSettings;
+  }
+
+  /** Returns the object with the settings used for calls to wait. */
+  public UnaryCallSettings<WaitOperationRequest, Operation> waitOperationSettings() {
+    return waitOperationSettings;
   }
 
   public SpeechStub createStub() throws IOException {
     if (getTransportChannelProvider()
-        .getTransportName()
-        .equals(GrpcTransportChannel.getGrpcTransportName())) {
+            .getTransportName()
+            .equals(GrpcTransportChannel.getGrpcTransportName())) {
       return GrpcSpeechStub.create(this);
     }
     if (getTransportChannelProvider()
-        .getTransportName()
-        .equals(HttpJsonTransportChannel.getHttpJsonTransportName())) {
+            .getTransportName()
+            .equals(HttpJsonTransportChannel.getHttpJsonTransportName())) {
       return HttpJsonSpeechStub.create(this);
     }
     throw new UnsupportedOperationException(
-        String.format(
-            "Transport not supported: %s", getTransportChannelProvider().getTransportName()));
+            String.format(
+                    "Transport not supported: %s", getTransportChannelProvider().getTransportName()));
   }
 
   /** Returns a builder for the default ExecutorProvider for this service. */
@@ -169,20 +273,20 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
     return GoogleCredentialsProvider.newBuilder()
-        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
-        .setUseJwtAccessWithScope(true);
+            .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+            .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default gRPC ChannelProvider for this service. */
   public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder() {
     return InstantiatingGrpcChannelProvider.newBuilder()
-        .setMaxInboundMessageSize(Integer.MAX_VALUE);
+            .setMaxInboundMessageSize(Integer.MAX_VALUE);
   }
 
   /** Returns a builder for the default REST ChannelProvider for this service. */
   @BetaApi
   public static InstantiatingHttpJsonChannelProvider.Builder
-      defaultHttpJsonTransportProviderBuilder() {
+  defaultHttpJsonTransportProviderBuilder() {
     return InstantiatingHttpJsonChannelProvider.newBuilder();
   }
 
@@ -193,18 +297,18 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultGrpcApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
-        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(SpeechStubSettings.class))
-        .setTransportToken(
-            GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
+            .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(SpeechStubSettings.class))
+            .setTransportToken(
+                    GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
   }
 
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultHttpJsonApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
-        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(SpeechStubSettings.class))
-        .setTransportToken(
-            GaxHttpJsonProperties.getHttpJsonTokenName(),
-            GaxHttpJsonProperties.getHttpJsonVersion());
+            .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(SpeechStubSettings.class))
+            .setTransportToken(
+                    GaxHttpJsonProperties.getHttpJsonTokenName(),
+                    GaxHttpJsonProperties.getHttpJsonVersion());
   }
 
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
@@ -237,8 +341,13 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
     recognizeSettings = settingsBuilder.recognizeSettings().build();
     longRunningRecognizeSettings = settingsBuilder.longRunningRecognizeSettings().build();
     longRunningRecognizeOperationSettings =
-        settingsBuilder.longRunningRecognizeOperationSettings().build();
+            settingsBuilder.longRunningRecognizeOperationSettings().build();
     streamingRecognizeSettings = settingsBuilder.streamingRecognizeSettings().build();
+    listOperationsSettings = settingsBuilder.listOperationsSettings().build();
+    getOperationSettings = settingsBuilder.getOperationSettings().build();
+    deleteOperationSettings = settingsBuilder.deleteOperationSettings().build();
+    cancelOperationSettings = settingsBuilder.cancelOperationSettings().build();
+    waitOperationSettings = settingsBuilder.waitOperationSettings().build();
   }
 
   /** Builder for SpeechStubSettings. */
@@ -246,26 +355,34 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
     private final UnaryCallSettings.Builder<RecognizeRequest, RecognizeResponse> recognizeSettings;
     private final UnaryCallSettings.Builder<LongRunningRecognizeRequest, Operation>
-        longRunningRecognizeSettings;
+            longRunningRecognizeSettings;
     private final OperationCallSettings.Builder<
             LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-        longRunningRecognizeOperationSettings;
+            longRunningRecognizeOperationSettings;
     private final StreamingCallSettings.Builder<
             StreamingRecognizeRequest, StreamingRecognizeResponse>
-        streamingRecognizeSettings;
+            streamingRecognizeSettings;
+    private final PagedCallSettings.Builder<
+            ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>
+            listOperationsSettings;
+    private final UnaryCallSettings.Builder<GetOperationRequest, Operation> getOperationSettings;
+    private final UnaryCallSettings.Builder<DeleteOperationRequest, Empty> deleteOperationSettings;
+    private final UnaryCallSettings.Builder<CancelOperationRequest, Empty> cancelOperationSettings;
+    private final UnaryCallSettings.Builder<WaitOperationRequest, Operation> waitOperationSettings;
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
-        RETRYABLE_CODE_DEFINITIONS;
+            RETRYABLE_CODE_DEFINITIONS;
 
     static {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions =
-          ImmutableMap.builder();
+              ImmutableMap.builder();
       definitions.put(
-          "retry_policy_0_codes",
-          ImmutableSet.copyOf(
-              Lists.<StatusCode.Code>newArrayList(
-                  StatusCode.Code.UNAVAILABLE, StatusCode.Code.DEADLINE_EXCEEDED)));
+              "retry_policy_0_codes",
+              ImmutableSet.copyOf(
+                      Lists.<StatusCode.Code>newArrayList(
+                              StatusCode.Code.UNAVAILABLE, StatusCode.Code.DEADLINE_EXCEEDED)));
       definitions.put(
-          "no_retry_1_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+              "no_retry_1_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      definitions.put("no_retry_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
       RETRYABLE_CODE_DEFINITIONS = definitions.build();
     }
 
@@ -275,24 +392,26 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
       ImmutableMap.Builder<String, RetrySettings> definitions = ImmutableMap.builder();
       RetrySettings settings = null;
       settings =
-          RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
-              .setRetryDelayMultiplier(1.3)
-              .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(5000000L))
-              .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(5000000L))
-              .setTotalTimeout(Duration.ofMillis(5000000L))
-              .build();
+              RetrySettings.newBuilder()
+                      .setInitialRetryDelay(Duration.ofMillis(100L))
+                      .setRetryDelayMultiplier(1.3)
+                      .setMaxRetryDelay(Duration.ofMillis(60000L))
+                      .setInitialRpcTimeout(Duration.ofMillis(5000000L))
+                      .setRpcTimeoutMultiplier(1.0)
+                      .setMaxRpcTimeout(Duration.ofMillis(5000000L))
+                      .setTotalTimeout(Duration.ofMillis(5000000L))
+                      .build();
       definitions.put("retry_policy_0_params", settings);
       settings =
-          RetrySettings.newBuilder()
-              .setInitialRpcTimeout(Duration.ofMillis(5000000L))
-              .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(5000000L))
-              .setTotalTimeout(Duration.ofMillis(5000000L))
-              .build();
+              RetrySettings.newBuilder()
+                      .setInitialRpcTimeout(Duration.ofMillis(5000000L))
+                      .setRpcTimeoutMultiplier(1.0)
+                      .setMaxRpcTimeout(Duration.ofMillis(5000000L))
+                      .setTotalTimeout(Duration.ofMillis(5000000L))
+                      .build();
       definitions.put("no_retry_1_params", settings);
+      settings = RetrySettings.newBuilder().setRpcTimeoutMultiplier(1.0).build();
+      definitions.put("no_retry_params", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();
     }
 
@@ -307,10 +426,21 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
       longRunningRecognizeSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
       longRunningRecognizeOperationSettings = OperationCallSettings.newBuilder();
       streamingRecognizeSettings = StreamingCallSettings.newBuilder();
+      listOperationsSettings = PagedCallSettings.newBuilder(LIST_OPERATIONS_PAGE_STR_FACT);
+      getOperationSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      deleteOperationSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      cancelOperationSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      waitOperationSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders =
-          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-              recognizeSettings, longRunningRecognizeSettings);
+              ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+                      recognizeSettings,
+                      longRunningRecognizeSettings,
+                      listOperationsSettings,
+                      getOperationSettings,
+                      deleteOperationSettings,
+                      cancelOperationSettings,
+                      waitOperationSettings);
       initDefaults(this);
     }
 
@@ -320,12 +450,23 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
       recognizeSettings = settings.recognizeSettings.toBuilder();
       longRunningRecognizeSettings = settings.longRunningRecognizeSettings.toBuilder();
       longRunningRecognizeOperationSettings =
-          settings.longRunningRecognizeOperationSettings.toBuilder();
+              settings.longRunningRecognizeOperationSettings.toBuilder();
       streamingRecognizeSettings = settings.streamingRecognizeSettings.toBuilder();
+      listOperationsSettings = settings.listOperationsSettings.toBuilder();
+      getOperationSettings = settings.getOperationSettings.toBuilder();
+      deleteOperationSettings = settings.deleteOperationSettings.toBuilder();
+      cancelOperationSettings = settings.cancelOperationSettings.toBuilder();
+      waitOperationSettings = settings.waitOperationSettings.toBuilder();
 
       unaryMethodSettingsBuilders =
-          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-              recognizeSettings, longRunningRecognizeSettings);
+              ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+                      recognizeSettings,
+                      longRunningRecognizeSettings,
+                      listOperationsSettings,
+                      getOperationSettings,
+                      deleteOperationSettings,
+                      cancelOperationSettings,
+                      waitOperationSettings);
     }
 
     private static Builder createDefault() {
@@ -356,40 +497,65 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
 
     private static Builder initDefaults(Builder builder) {
       builder
-          .recognizeSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_0_codes"))
-          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_0_params"));
+              .recognizeSettings()
+              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_0_codes"))
+              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_0_params"));
 
       builder
-          .longRunningRecognizeSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
-          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"));
+              .longRunningRecognizeSettings()
+              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
+              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"));
 
       builder
-          .longRunningRecognizeOperationSettings()
-          .setInitialCallSettings(
-              UnaryCallSettings
-                  .<LongRunningRecognizeRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
-                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
-                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"))
-                  .build())
-          .setResponseTransformer(
-              ProtoOperationTransformers.ResponseTransformer.create(
-                  LongRunningRecognizeResponse.class))
-          .setMetadataTransformer(
-              ProtoOperationTransformers.MetadataTransformer.create(
-                  LongRunningRecognizeMetadata.class))
-          .setPollingAlgorithm(
-              OperationTimedPollAlgorithm.create(
-                  RetrySettings.newBuilder()
-                      .setInitialRetryDelay(Duration.ofMillis(5000L))
-                      .setRetryDelayMultiplier(1.5)
-                      .setMaxRetryDelay(Duration.ofMillis(45000L))
-                      .setInitialRpcTimeout(Duration.ZERO)
-                      .setRpcTimeoutMultiplier(1.0)
-                      .setMaxRpcTimeout(Duration.ZERO)
-                      .setTotalTimeout(Duration.ofMillis(300000L))
-                      .build()));
+              .listOperationsSettings()
+              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+              .getOperationSettings()
+              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+              .deleteOperationSettings()
+              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+              .cancelOperationSettings()
+              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+              .waitOperationSettings()
+              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+              .longRunningRecognizeOperationSettings()
+              .setInitialCallSettings(
+                      UnaryCallSettings
+                              .<LongRunningRecognizeRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
+                              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
+                              .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"))
+                              .build())
+              .setResponseTransformer(
+                      ProtoOperationTransformers.ResponseTransformer.create(
+                              LongRunningRecognizeResponse.class))
+              .setMetadataTransformer(
+                      ProtoOperationTransformers.MetadataTransformer.create(
+                              LongRunningRecognizeMetadata.class))
+              .setPollingAlgorithm(
+                      OperationTimedPollAlgorithm.create(
+                              RetrySettings.newBuilder()
+                                      .setInitialRetryDelay(Duration.ofMillis(5000L))
+                                      .setRetryDelayMultiplier(1.5)
+                                      .setMaxRetryDelay(Duration.ofMillis(45000L))
+                                      .setInitialRpcTimeout(Duration.ZERO)
+                                      .setRpcTimeoutMultiplier(1.0)
+                                      .setMaxRpcTimeout(Duration.ZERO)
+                                      .setTotalTimeout(Duration.ofMillis(300000L))
+                                      .build()));
 
       return builder;
     }
@@ -400,7 +566,7 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
      * <p>Note: This method does not support applying settings to streaming methods.
      */
     public Builder applyToAllUnaryMethods(
-        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
+            ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
       super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, settingsUpdater);
       return this;
     }
@@ -416,23 +582,50 @@ public class SpeechStubSettings extends StubSettings<SpeechStubSettings> {
 
     /** Returns the builder for the settings used for calls to longRunningRecognize. */
     public UnaryCallSettings.Builder<LongRunningRecognizeRequest, Operation>
-        longRunningRecognizeSettings() {
+    longRunningRecognizeSettings() {
       return longRunningRecognizeSettings;
     }
 
     /** Returns the builder for the settings used for calls to longRunningRecognize. */
     @BetaApi(
-        "The surface for use by generated code is not stable yet and may change in the future.")
+            "The surface for use by generated code is not stable yet and may change in the future.")
     public OperationCallSettings.Builder<
             LongRunningRecognizeRequest, LongRunningRecognizeResponse, LongRunningRecognizeMetadata>
-        longRunningRecognizeOperationSettings() {
+    longRunningRecognizeOperationSettings() {
       return longRunningRecognizeOperationSettings;
     }
 
     /** Returns the builder for the settings used for calls to streamingRecognize. */
     public StreamingCallSettings.Builder<StreamingRecognizeRequest, StreamingRecognizeResponse>
-        streamingRecognizeSettings() {
+    streamingRecognizeSettings() {
       return streamingRecognizeSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to listOperations. */
+    public PagedCallSettings.Builder<
+            ListOperationsRequest, ListOperationsResponse, ListOperationsPagedResponse>
+    listOperationsSettings() {
+      return listOperationsSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to get. */
+    public UnaryCallSettings.Builder<GetOperationRequest, Operation> getOperationSettings() {
+      return getOperationSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to delete. */
+    public UnaryCallSettings.Builder<DeleteOperationRequest, Empty> deleteOperationSettings() {
+      return deleteOperationSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to cancel. */
+    public UnaryCallSettings.Builder<CancelOperationRequest, Empty> cancelOperationSettings() {
+      return cancelOperationSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to wait. */
+    public UnaryCallSettings.Builder<WaitOperationRequest, Operation> waitOperationSettings() {
+      return waitOperationSettings;
     }
 
     @Override

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1p1beta1/stub/HttpJsonAdaptationCallableFactory.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1p1beta1/stub/HttpJsonAdaptationCallableFactory.java
@@ -24,6 +24,7 @@ import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.httpjson.longrunning.stub.OperationsStub;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.LongRunningClient;
 import com.google.api.gax.rpc.OperationCallSettings;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PagedCallSettings;
@@ -91,6 +92,11 @@ public class HttpJsonAdaptationCallableFactory
             httpJsonCallSettings.getMethodDescriptor().getOperationSnapshotFactory());
     return HttpJsonCallableFactory.createOperationCallable(
         callSettings, clientContext, operationsStub.longRunningClient(), initialCallable);
+  }
+
+  @Override
+  public <RequestT, ResponseT, MetadataT> OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings, OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings, ClientContext clientContext, LongRunningClient longRunningClient) {
+    return null;
   }
 
   @Override

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1p1beta1/stub/HttpJsonAdaptationCallableFactory.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1p1beta1/stub/HttpJsonAdaptationCallableFactory.java
@@ -95,7 +95,12 @@ public class HttpJsonAdaptationCallableFactory
   }
 
   @Override
-  public <RequestT, ResponseT, MetadataT> OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings, OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings, ClientContext clientContext, LongRunningClient longRunningClient) {
+  public <RequestT, ResponseT, MetadataT>
+      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+          HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings,
+          OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
+          ClientContext clientContext,
+          LongRunningClient longRunningClient) {
     return null;
   }
 

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1p1beta1/stub/HttpJsonSpeechCallableFactory.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1p1beta1/stub/HttpJsonSpeechCallableFactory.java
@@ -95,7 +95,12 @@ public class HttpJsonSpeechCallableFactory
   }
 
   @Override
-  public <RequestT, ResponseT, MetadataT> OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings, OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings, ClientContext clientContext, LongRunningClient longRunningClient) {
+  public <RequestT, ResponseT, MetadataT>
+      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+          HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings,
+          OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
+          ClientContext clientContext,
+          LongRunningClient longRunningClient) {
     return null;
   }
 

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1p1beta1/stub/HttpJsonSpeechCallableFactory.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v1p1beta1/stub/HttpJsonSpeechCallableFactory.java
@@ -24,6 +24,7 @@ import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.httpjson.longrunning.stub.OperationsStub;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.LongRunningClient;
 import com.google.api.gax.rpc.OperationCallSettings;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PagedCallSettings;
@@ -91,6 +92,11 @@ public class HttpJsonSpeechCallableFactory
             httpJsonCallSettings.getMethodDescriptor().getOperationSnapshotFactory());
     return HttpJsonCallableFactory.createOperationCallable(
         callSettings, clientContext, operationsStub.longRunningClient(), initialCallable);
+  }
+
+  @Override
+  public <RequestT, ResponseT, MetadataT> OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings, OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings, ClientContext clientContext, LongRunningClient longRunningClient) {
+    return null;
   }
 
   @Override

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v2/stub/HttpJsonSpeechCallableFactory.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v2/stub/HttpJsonSpeechCallableFactory.java
@@ -95,7 +95,12 @@ public class HttpJsonSpeechCallableFactory
   }
 
   @Override
-  public <RequestT, ResponseT, MetadataT> OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings, OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings, ClientContext clientContext, LongRunningClient longRunningClient) {
+  public <RequestT, ResponseT, MetadataT>
+      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+          HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings,
+          OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
+          ClientContext clientContext,
+          LongRunningClient longRunningClient) {
     return null;
   }
 

--- a/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v2/stub/HttpJsonSpeechCallableFactory.java
+++ b/java-speech/google-cloud-speech/src/main/java/com/google/cloud/speech/v2/stub/HttpJsonSpeechCallableFactory.java
@@ -24,6 +24,7 @@ import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.httpjson.longrunning.stub.OperationsStub;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.LongRunningClient;
 import com.google.api.gax.rpc.OperationCallSettings;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PagedCallSettings;
@@ -91,6 +92,11 @@ public class HttpJsonSpeechCallableFactory
             httpJsonCallSettings.getMethodDescriptor().getOperationSnapshotFactory());
     return HttpJsonCallableFactory.createOperationCallable(
         callSettings, clientContext, operationsStub.longRunningClient(), initialCallable);
+  }
+
+  @Override
+  public <RequestT, ResponseT, MetadataT> OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings, OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings, ClientContext clientContext, LongRunningClient longRunningClient) {
+    return null;
   }
 
   @Override


### PR DESCRIPTION
Example of possible implementation for creating Operation RPC Callables in the SpeechClient


GAX-HttpJson changes - Create an overloaded `createOperationCallable` method for creating an OperationCallable:

Old:
```
  /**
   * Creates a callable object that represents a long-running operation. Designed for use by
   * generated code.
   *
   * @param httpJsonCallSettings the http/json call settings
   * @param operationCallSettings {@link OperationCallSettings} to configure the method-level
   *     settings with
   * @param clientContext {@link ClientContext} to use to connect to the service
   * @param operationsStub opertation stub to use to poll for updates on the Operation
   * @return {@link OperationCallable} callable object
   */
  <RequestT, ResponseT, MetadataT>
      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
          HttpJsonCallSettings<RequestT, OperationT> httpJsonCallSettings,
          OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
          ClientContext clientContext,
          OperationsStub operationsStub);
```

New:
```
  /**
   * Creates a callable object that represents a long-running operation. Designed for use by
   * generated code.
   *
   * @param httpJsonCallSettings the http/json call settings
   * @param operationCallSettings {@link OperationCallSettings} to configure the method-level
   *     settings with
   * @param clientContext {@link ClientContext} to use to connect to the service
   * @param longRunningClient LongRunningClient to poll for updates on the Operation
   * @return {@link OperationCallable} callable object
   */
  <RequestT, ResponseT, MetadataT>
      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
          HttpJsonCallSettings<RequestT, OperationT> httpJsonCallSettings,
          OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
          ClientContext clientContext,
          LongRunningClient longRunningClient);
```

Output:
```
com.google.cloud.speech.v1.Main
Running with REST...
Transcript: how old is the Brooklyn Bridge
```